### PR TITLE
add mechanism to trace pkg with no sentiment details

### DIFF
--- a/bayesian/api_v1.py
+++ b/bayesian/api_v1.py
@@ -342,45 +342,44 @@ class StackAnalysesGETV2(ResourceWithSchema):
         manifest_response = []
         recommendation = {}
 
-        if stack_result != None and 'task_result' in stack_result:
+        if stack_result != None:
             if stack_result["task_result"] != None:
                 started_at = stack_result["task_result"]["_audit"]["started_at"]
                 finished_at = stack_result["task_result"]["_audit"]["ended_at"]
 
         if reco_result is not None and 'task_result' in reco_result:
-                if reco_result["task_result"] != None:
-                    recommendation = reco_result['task_result']['recommendations']
+            if reco_result["task_result"] != None:
+                recommendation = reco_result['task_result']['recommendations']
 
         # Populate sentiment score for packages in user's stack
         if stack_result is not None:
-            user_stack_deps = stack_result.get('task_result').get('user_stack_info').get('dependencies',[])
-            if user_stack_deps:
-                for dep in user_stack_deps:
-                    if user_stack_sentiment_result is not None:
-                        if user_stack_sentiment_result.get('task_result').get(dep['name']) is not None:
-                            dep['sentiment']['overall_score'] = user_stack_sentiment_result.get('task_result').\
-                                get(dep['name']).get('score', 0)
-                        else:
-                            dep['sentiment'] = {}
+            user_stack_deps = stack_result['task_result']['user_stack_info'].get('dependencies',[])
+            for dep in user_stack_deps:
+                if user_stack_sentiment_result is not None:
+                    user_stack_sentiment = user_stack_sentiment_result.get('task_result')
+                    print("i am user_stack", user_stack_sentiment)
+                    if user_stack_sentiment.get(dep['name']) is not None:
+                        dep['sentiment']['overall_score'] = user_stack_sentiment.get(dep['name']).get('score', 0)
+                    else:
+                        dep['sentiment'] = {}
 
         # Populate sentiment score for recommended packages
         if reco_result is not None:
             alternate = reco_result.get('task_result').get('recommendations').get('alternate', [])
-            if alternate:
-                for pkg in alternate:
-                    if reco_pkg_sentiment_result.get("task_result") is not None:
-                        if reco_pkg_sentiment_result.get('task_result').get(dep['name']) is not None:
-                            pkg['sentiment']['overall_score'] = reco_pkg_sentiment_result.get('task_result').\
-                                get(dep['name']).get('score', 0)
-                        else:
-                            pkg['sentiment'] = {}
+            for pkg in alternate:
+                if reco_pkg_sentiment_result is not None:
+                    reco_pkg_sentiment_alter = reco_pkg_sentiment_result.get('task_result')
+                    if reco_pkg_sentiment_alter is not None:
+                        pkg['sentiment']['overall_score'] = reco_pkg_sentiment_alter.get(pkg['name'], {}).get('score', 0)
+                    else:
+                        pkg['sentiment'] = {}
 
             companion = reco_result.get('task_result').get('recommendations').get('companion',[])
-
-            if companion:
-                for pkg in companion:
-                    if reco_pkg_sentiment_result['task_result'] is not None:
-                        pkg['sentiment']['overall_score'] = reco_pkg_sentiment_result['task_result'].get(pkg['name']).get('score', 0)
+            for pkg in companion:
+                if reco_pkg_sentiment_result is not None:
+                    reco_pkg_sentiment_companion = reco_pkg_sentiment_result.get('task_result')
+                    if reco_pkg_sentiment_companion is not None:
+                        pkg['sentiment']['overall_score'] = reco_pkg_sentiment_companion.get(pkg['name'], {}).get('score', 0)
                     else:
                         pkg['sentiment'] = {}
 

--- a/bayesian/api_v1.py
+++ b/bayesian/api_v1.py
@@ -349,39 +349,52 @@ class StackAnalysesGETV2(ResourceWithSchema):
 
         if reco_result is not None and 'task_result' in reco_result:
             if reco_result["task_result"] != None:
-                recommendation = reco_result['task_result']['recommendations']
+                recommendation = reco_result.get('task_result').get('recommendations', {})
 
         # Populate sentiment score for packages in user's stack
         if stack_result is not None:
-            user_stack_deps = stack_result['task_result']['user_stack_info'].get('dependencies',[])
+            user_stack_deps = stack_result.get('task_result', {}).get('user_stack_info', {}).get('dependencies',[])
             for dep in user_stack_deps:
                 if user_stack_sentiment_result is not None:
-                    user_stack_sentiment = user_stack_sentiment_result.get('task_result')
-                    print("i am user_stack", user_stack_sentiment)
+                    user_stack_sentiment = user_stack_sentiment_result.get('task_result', {})
                     if user_stack_sentiment.get(dep['name']) is not None:
                         dep['sentiment']['overall_score'] = user_stack_sentiment.get(dep['name']).get('score', 0)
+                        dep['sentiment']['magnitude'] = user_stack_sentiment.get(dep['name'], {}).get('magnitude', 0)
                     else:
-                        dep['sentiment'] = {}
+                        dep['sentiment'] = {
+                            "latest_comment": "",
+                            "overall_score": 0,
+                            "magnitude": 0
+                        }
 
         # Populate sentiment score for recommended packages
         if reco_result is not None:
-            alternate = reco_result.get('task_result').get('recommendations').get('alternate', [])
+            alternate = reco_result.get('task_result', {}).get('recommendations', {}).get('alternate', [])
             for pkg in alternate:
                 if reco_pkg_sentiment_result is not None:
-                    reco_pkg_sentiment_alter = reco_pkg_sentiment_result.get('task_result')
+                    reco_pkg_sentiment_alter = reco_pkg_sentiment_result.get('task_result', {})
                     if reco_pkg_sentiment_alter is not None:
                         pkg['sentiment']['overall_score'] = reco_pkg_sentiment_alter.get(pkg['name'], {}).get('score', 0)
+                        pkg['sentiment']['magnitude'] = reco_pkg_sentiment_alter.get(pkg['name'], {}).get('magnitude', 0)
                     else:
-                        pkg['sentiment'] = {}
-
-            companion = reco_result.get('task_result').get('recommendations').get('companion',[])
+                        pkg['sentiment'] = {
+                            "latest_comment": "",
+                            "overall_score": 0,
+                            "magnitude": 0
+                        }
+            companion = reco_result.get('task_result', {}).get('recommendations', {}).get('companion',[])
             for pkg in companion:
                 if reco_pkg_sentiment_result is not None:
-                    reco_pkg_sentiment_companion = reco_pkg_sentiment_result.get('task_result')
+                    reco_pkg_sentiment_companion = reco_pkg_sentiment_result.get('task_result', {})
                     if reco_pkg_sentiment_companion is not None:
                         pkg['sentiment']['overall_score'] = reco_pkg_sentiment_companion.get(pkg['name'], {}).get('score', 0)
+                        pkg['sentiment']['magnitude'] = reco_pkg_sentiment_companion.get(pkg['name'], {}).get('magnitude', 0)
                     else:
-                        pkg['sentiment'] = {}
+                        pkg['sentiment'] = {
+                            "latest_comment": "",
+                            "overall_score": 0,
+                            "magnitude": 0
+                        }
 
         stack_result['task_result']['recommendations'] = recommendation
         manifest_response.append(stack_result["task_result"])

--- a/bayesian/api_v1.py
+++ b/bayesian/api_v1.py
@@ -347,20 +347,17 @@ class StackAnalysesGETV2(ResourceWithSchema):
                 started_at = stack_result["task_result"]["_audit"]["started_at"]
                 finished_at = stack_result["task_result"]["_audit"]["ended_at"]
 
-
-        if reco_result is not None and 'task_result' in reco_result:
-            if reco_result["task_result"] != None:
-                recommendation = reco_result['task_result']['recommendations']
-
         # Populate sentiment score for packages in user's stack
         if stack_result is not None:
             user_stack_deps = stack_result.get('task_result').get('user_stack_info').get('dependencies',[])
             if user_stack_deps:
                 for dep in user_stack_deps:
                     if user_stack_sentiment_result is not None:
-                        dep['sentiment']['overall_score'] = user_stack_sentiment_result.get('task_result').get(dep['name']).get('score', 0)
-                    else:
-                        dep['sentiment'] = {}
+                        if user_stack_sentiment_result.get('task_result').get(dep['name']) is not None:
+                            dep['sentiment']['overall_score'] = user_stack_sentiment_result.get('task_result').\
+                                get(dep['name']).get('score', 0)
+                        else:
+                            dep['sentiment'] = {}
 
         # Populate sentiment score for recommended packages
         if reco_result is not None:
@@ -368,17 +365,24 @@ class StackAnalysesGETV2(ResourceWithSchema):
             if alternate:
                 for pkg in alternate:
                     if reco_pkg_sentiment_result.get("task_result") is not None:
-                        pkg['sentiment']['overall_score'] = reco_pkg_sentiment_result.get('task_result').get(dep['name']).get('score', 0)
-                    else:
-                        pkg['sentiment'] = {}
+                        if reco_pkg_sentiment_result.get('task_result').get(dep['name']) is not None:
+                            pkg['sentiment']['overall_score'] = reco_pkg_sentiment_result.get('task_result').\
+                                get(dep['name']).get('score', 0)
+                        else:
+                            pkg['sentiment'] = {}
 
             companion = reco_result.get('task_result').get('recommendations').get('companion',[])
+
             if companion:
                 for pkg in companion:
                     if reco_pkg_sentiment_result['task_result'] is not None:
                         pkg['sentiment']['overall_score'] = reco_pkg_sentiment_result['task_result'].get(pkg['name']).get('score', 0)
                     else:
                         pkg['sentiment'] = {}
+
+            if reco_result is not None and 'task_result' in reco_result:
+                if reco_result["task_result"] != None:
+                    recommendation = reco_result['task_result']['recommendations']
 
         stack_result['task_result']['recommendations'] = recommendation
         manifest_response.append(stack_result["task_result"])

--- a/bayesian/api_v1.py
+++ b/bayesian/api_v1.py
@@ -354,28 +354,31 @@ class StackAnalysesGETV2(ResourceWithSchema):
 
         # Populate sentiment score for packages in user's stack
         if stack_result is not None:
-            user_stack_deps = stack_result['task_result']['user_stack_info']['dependencies']
-            for dep in user_stack_deps:
-                if user_stack_sentiment_result is not None:
-                    dep['sentiment']['overall_score'] = user_stack_sentiment_result['task_result'][dep['name']]['score']
-                else:
-                    dep['sentiment'] = {}
+            user_stack_deps = stack_result.get('task_result').get('user_stack_info').get('dependencies',[])
+            if user_stack_deps:
+                for dep in user_stack_deps:
+                    if user_stack_sentiment_result is not None:
+                        dep['sentiment']['overall_score'] = user_stack_sentiment_result.get('task_result').get(dep['name']).get('score', 0)
+                    else:
+                        dep['sentiment'] = {}
 
         # Populate sentiment score for recommended packages
         if reco_result is not None:
-            alternate = reco_result['task_result']['recommendations']['alternate']
-            for pkg in alternate:
-                if reco_pkg_sentiment_result is not None:
-                    pkg['sentiment']['overall_score'] = reco_pkg_sentiment_result['task_result'][pkg['name']]['score']
-                else:
-                    pkg['sentiment'] = {}
+            alternate = reco_result.get('task_result').get('recommendations').get('alternate', [])
+            if alternate:
+                for pkg in alternate:
+                    if reco_pkg_sentiment_result.get("task_result") is not None:
+                        pkg['sentiment']['overall_score'] = reco_pkg_sentiment_result.get('task_result').get(dep['name']).get('score', 0)
+                    else:
+                        pkg['sentiment'] = {}
 
-            companion = reco_result['task_result']['recommendations']['companion']
-            for pkg in companion:
-                if reco_pkg_sentiment_result is not None:
-                    pkg['sentiment']['overall_score'] = reco_pkg_sentiment_result['task_result'][pkg['name']]['score']
-                else:
-                    pkg['sentiment'] = {}
+            companion = reco_result.get('task_result').get('recommendations').get('companion',[])
+            if companion:
+                for pkg in companion:
+                    if reco_pkg_sentiment_result['task_result'] is not None:
+                        pkg['sentiment']['overall_score'] = reco_pkg_sentiment_result['task_result'].get(pkg['name']).get('score', 0)
+                    else:
+                        pkg['sentiment'] = {}
 
         stack_result['task_result']['recommendations'] = recommendation
         manifest_response.append(stack_result["task_result"])

--- a/bayesian/api_v1.py
+++ b/bayesian/api_v1.py
@@ -347,6 +347,10 @@ class StackAnalysesGETV2(ResourceWithSchema):
                 started_at = stack_result["task_result"]["_audit"]["started_at"]
                 finished_at = stack_result["task_result"]["_audit"]["ended_at"]
 
+        if reco_result is not None and 'task_result' in reco_result:
+                if reco_result["task_result"] != None:
+                    recommendation = reco_result['task_result']['recommendations']
+
         # Populate sentiment score for packages in user's stack
         if stack_result is not None:
             user_stack_deps = stack_result.get('task_result').get('user_stack_info').get('dependencies',[])
@@ -379,10 +383,6 @@ class StackAnalysesGETV2(ResourceWithSchema):
                         pkg['sentiment']['overall_score'] = reco_pkg_sentiment_result['task_result'].get(pkg['name']).get('score', 0)
                     else:
                         pkg['sentiment'] = {}
-
-            if reco_result is not None and 'task_result' in reco_result:
-                if reco_result["task_result"] != None:
-                    recommendation = reco_result['task_result']['recommendations']
 
         stack_result['task_result']['recommendations'] = recommendation
         manifest_response.append(stack_result["task_result"])

--- a/bayesian/api_v1.py
+++ b/bayesian/api_v1.py
@@ -350,6 +350,8 @@ class StackAnalysesGETV2(ResourceWithSchema):
         if reco_result is not None and 'task_result' in reco_result:
             if reco_result["task_result"] != None:
                 recommendation = reco_result.get('task_result').get('recommendations', {})
+            else:
+                current_app.logger.info("task results for recommendation does't exit.")
 
         # Populate sentiment score for packages in user's stack
         if stack_result is not None:
@@ -366,6 +368,7 @@ class StackAnalysesGETV2(ResourceWithSchema):
                             "overall_score": 0,
                             "magnitude": 0
                         }
+        current_app.logger.info("Sentiment Analysis for User Stack is completed successfully" )
 
         # Populate sentiment score for recommended packages
         if reco_result is not None:
@@ -382,6 +385,7 @@ class StackAnalysesGETV2(ResourceWithSchema):
                             "overall_score": 0,
                             "magnitude": 0
                         }
+            current_app.logger.info("Sentiment Analysis for Alternate Packages is completed successfully.")
             companion = reco_result.get('task_result', {}).get('recommendations', {}).get('companion',[])
             for pkg in companion:
                 if reco_pkg_sentiment_result is not None:
@@ -395,6 +399,7 @@ class StackAnalysesGETV2(ResourceWithSchema):
                             "overall_score": 0,
                             "magnitude": 0
                         }
+            current_app.logger.info("Sentiment Analysis for Companion Packages is completed successfully.")
 
         stack_result['task_result']['recommendations'] = recommendation
         manifest_response.append(stack_result["task_result"])

--- a/bayesian/api_v1.py
+++ b/bayesian/api_v1.py
@@ -342,7 +342,7 @@ class StackAnalysesGETV2(ResourceWithSchema):
         manifest_response = []
         recommendation = {}
 
-        if stack_result != None:
+        if stack_result != None and 'task_result' in stack_result:
             if stack_result["task_result"] != None:
                 started_at = stack_result["task_result"]["_audit"]["started_at"]
                 finished_at = stack_result["task_result"]["_audit"]["ended_at"]


### PR DESCRIPTION
Hi,
This PR is created to resolve the condition, when we have no sentiment details for user_stack analysis, which is generating nontype attribute, details of the error is given in : http://pastebin.test.redhat.com/504244 

However, this is not the complete solution, but it avoids the error this time, and requires further enhancement.
Thanks,
Saket