### PR TITLE
stackApiGraphV2Flow to not contain data with manifests

### DIFF
--- a/bayesian/api_v1.py
+++ b/bayesian/api_v1.py
@@ -631,7 +631,7 @@ class StackAnalyses(ResourceWithSchema):
             raise HTTPError(500, "Error inserting log for request {t}".format(t=request_id)) from e
 
         try:
-            data = {'api_name': 'stack_analyses', 'request': manifests,
+            data = {'api_name': 'stack_analyses',
                     'user_email': decoded.get('email','bayesian@redhat.com'),
                     'user_profile': decoded}
             args = {'external_request_id': request_id, 'ecosystem': ecosystem, 'data': data}


### PR DESCRIPTION
The manifests data size can be huge which may not be supported by the SQS queue. The fix is to fetch the manifests data from the already existing requestJson field of stack_analyses_request RDS table in GraphAggregatorTask and ManifestKeeperTask.