### PR TITLE
Return empty dict if no token has been provided

### DIFF
--- a/bayesian/auth.py
+++ b/bayesian/auth.py
@@ -27,7 +27,7 @@ def decode_token():
 
     pub_key = fetch_public_key(current_app)
     audiences = current_app.config.get('BAYESIAN_JWT_AUDIENCE').split(',')
-    aud_len = len(audiences)
+
     for aud in audiences:
         try:
             decoded_token = jwt.decode(token, pub_key, audience=aud)

--- a/bayesian/auth.py
+++ b/bayesian/auth.py
@@ -20,7 +20,7 @@ jwt.register_algorithm('RS256', RSAAlgorithm(RSAAlgorithm.SHA256))
 def decode_token():
     token = request.headers.get('Authorization')
     if token is None:
-        return token
+        return {}
 
     if token.startswith('Bearer '):
         _, token = token.split(' ', 1)


### PR DESCRIPTION
This allows me to test api locally without seeing:

```
coreapi-server  | Failed to schedule AggregatingMercatorTask for id 7d1f1b5cb6144adcbc7240e395f3c0dc
coreapi-server  | --------------------------------------------------------------------------------
coreapi-server  | Traceback (most recent call last):
coreapi-server  |    File "/usr/lib/python3.4/site-packages/bayesian/api_v1.py", line 725, in post
coreapi-server  |      'user_email': decoded.get('email', 'bayesian@redhat.com'),
coreapi-server  |    AttributeError: 'NoneType' object has no attribute 'get'
```

and

```
worker-api_1    | File "/usr/lib/python3.4/site-packages/f8a_worker/workers/bookkeeper.py", line 58, in execute
worker-api_1    |     if arguments['data'].get('api_name') == 'stack_analyses' and 'email' in arguments['data'].get('user_profile', {}):
worker-api_1    | TypeError: argument of type 'NoneType' is not iterable
```