### PR TITLE
Changed the logic of stack analysis using a github url

### DIFF
--- a/bayesian/api_v1.py
+++ b/bayesian/api_v1.py
@@ -911,8 +911,9 @@ class StackAnalyses(ResourceWithSchema):
                     if response.status_code == 200:
                         content = response.text
                 except request.exceptions.RequestException as e:
-                    current_app.logger.warn('contents for manifest file {}/{} could not be downloaded. '\
-                        'continuing with other manifest files in the GitHub repo'.format(filepath,filename))
+                    current_app.logger.warn('contents for manifest file {}/{} could not be '
+                                            'downloaded. continuing with other manifest files '
+                                            'in the GitHub repo'.format(filepath, filename))
                     continue
             else:
                 filename = manifest_file_raw.filename

--- a/bayesian/utils.py
+++ b/bayesian/utils.py
@@ -582,6 +582,7 @@ class GithubRead:
         return manifest_file_paths
 
     def get_manifest_details(self, github_url):
+        """Retrieve manifest files from cloned repository."""
         manifest_data = []
         supported_manifests = {
             'requirements.txt': True,
@@ -594,7 +595,8 @@ class GithubRead:
         else:
             return None
 
-        last_commit_url = 'https://api.github.com/repos/{project}/{repo}/git/refs/heads/master'.format(project=project, repo=repo)
+        last_commit_url = 'https://api.github.com/repos/{project}/{repo}/git/refs/heads/' \
+                          'master'.format(project=project, repo=repo)
         trees_url = 'https://api.github.com/repos/{project}/{repo}/git/trees/{sha}?recursive=1'
         raw_content_path = 'https://raw.githubusercontent.com/{project}/{repo}/master/{filename}'
 
@@ -602,7 +604,7 @@ class GithubRead:
         try:
             resp = get(last_commit_url)
         except exceptions.RequestException as e:
-            print (e)
+            print(e)
             return None
 
         last_commit = ''
@@ -610,21 +612,21 @@ class GithubRead:
             try:
                 last_commit = resp.json()['object']['sha']
             except KeyError as e:
-                print (e)
+                print(e)
                 return None
 
         # Fetch the contents tree using the last commit sha
         try:
             resp = get(trees_url.format(project=project, repo=repo, sha=last_commit))
         except exceptions.RequestException as e:
-            print (e)
+            print(e)
             return None
 
         if resp.status_code == 200:
             try:
                 tree = resp.json()['tree']
             except KeyError as e:
-                print (e)
+                print(e)
                 return None
 
         for t in tree:
@@ -632,11 +634,12 @@ class GithubRead:
                 if supported_manifests[os.path.basename(t['path'])]:
                     manifest_data.append({
                         'filename': os.path.basename(t['path']),
-                        'download_url': raw_content_path.format(project=project, repo=repo, filename=t['path']),
+                        'download_url': raw_content_path.format(
+                            project=project, repo=repo, filename=t['path']),
                         'filepath': os.path.dirname(t['path'])
                     })
             except KeyError as e:
-                print (e)
+                print(e)
                 continue
 
         return manifest_data


### PR DESCRIPTION
The existing implementation of performing stack analysis by means of a GitHub URL as parameter clones the repo, finds the manifest files and then extracts the content of those files to be stored in the RDS against the request ID.

The use of GitHub clone results in regular exceptions mentioned in the issue https://github.com/openshiftio/openshift.io/issues/814.

This PR addresses the problem in another way:
1.  Fetch the SHA for the last commit of the repo.
2.  Fetch the content tree recursively to fetch all the files with their corresponding directories.
3.  Find out the manifest file location from the fetched tree and generate the raw contents URL for those files.
4.  Download those manifest file contents from the generated GitHub raw contents URL.

This solution is aimed to work on any platform by standard GitHub API endpoint calls.