### PR TITLE
Added home area for user coreapi

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ MAINTAINER Pavel Odvody <podvody@redhat.com>
 ENV LANG=en_US.UTF-8 \
     F8A_WORKER_VERSION=aa32fa7
 
-RUN useradd coreapi
+RUN useradd -d /coreapi coreapi
 # python3-pycurl is needed for Amazon SQS (boto lib), we need CentOS' rpm - installing it from pip results in NSS errors
 RUN yum install -y epel-release &&\
     yum install -y gcc patch git python34-pip python34-requests httpd httpd-devel python34-devel postgresql-devel redhat-rpm-config libxml2-devel libxslt-devel python34-pycurl &&\


### PR DESCRIPTION
This should fix the issue https://github.com/openshiftio/openshift.io/issues/814.

The theory is that - coreapi user is created without a home area whereas .gitconfig file needs a home to get created.