### PR TITLE
Add missing backbone server port in environment variable

### DIFF
--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -35,7 +35,7 @@ objects:
           - name: WORKER_ADMINISTRATION_REGION
             value: "api"
           - name: F8_API_BACKBONE_HOST
-            value: "http://f8a-server-backbone"
+            value: "http://f8a-server-backbone:5000"
           - name: FUTURES_SESSION_WORKER_COUNT
             value: "100"
           - name: PGBOUNCER_SERVICE_HOST


### PR DESCRIPTION
The default value for `F8_API_BACKBONE_HOST` environment variable should be set to `"http://f8a-server-backbone:5000"`