### PR TITLE
Generate code coverage report on CI

### DIFF
--- a/Dockerfile.tests
+++ b/Dockerfile.tests
@@ -1,14 +1,18 @@
 FROM registry.devshift.net/bayesian/bayesian-api
 MAINTAINER Tomas Tomecek <ttomecek@redhat.com>
 
-COPY . /bayesian
-WORKDIR /bayesian
-RUN cd tests && pip3 install -r ./requirements.txt
+ENV PYTHONDONTWRITEBYTECODE 1
 
-ENV PYTHONDONTWRITEBYTECODE=1
+COPY . /bayesian
+RUN cd /bayesian/tests && pip3 install -r ./requirements.txt
+
 ENV POSTGRESQL_USER=coreapi
 ENV POSTGRESQL_PASSWORD=coreapi
 ENV POSTGRESQL_DATABASE=coreapi
 ENV PGBOUNCER_SERVICE_HOST=coreapi-pgbouncer
 
-ENTRYPOINT ["/bayesian/hack/exec_tests.sh"]
+# This is needed for codecov so the CWD is writeable and codecov can write stats to a file.
+WORKDIR /tmp
+
+CMD ["py.test"]
+# ENTRYPOINT ["/bayesian/hack/exec_tests.sh"]

--- a/hack/exec_tests.sh
+++ b/hack/exec_tests.sh
@@ -2,4 +2,6 @@
 
 set -e
 
-py.test -p no:cacheprovider -vv $@
+# we need no:cacheprovider, otherwise pytest will try to write to directory .cache which is in /usr under unprivileged
+# user and will cause exception
+py.test -p no:cacheprovider --cov=/bayesian/bayesian/ --cov-report term-missing -vv $@

--- a/runtest.sh
+++ b/runtest.sh
@@ -78,7 +78,6 @@ docker run -t \
   -e PGBOUNCER_SERVICE_HOST=${DB_CONTAINER_NAME} \
   -e DEPLOYMENT_PREFIX='test' \
   -e WORKER_ADMINISTRATION_REGION='api' \
-  $TEST_IMAGE_NAME $@ tests/
+  ${TEST_IMAGE_NAME} /bayesian/hack/exec_tests.sh $@ /bayesian/tests/
 
 echo "Test suite passed \\o/"
-

--- a/tests/requirements.in
+++ b/tests/requirements.in
@@ -2,6 +2,7 @@ flexmock
 freezegun
 pytest >= 3 # Needed for compatibility with celery 4.x fixtures
 pytest-flask
+pytest-cov
 requests
 jsonschema
 pylint

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -6,6 +6,7 @@
 #
 astroid==1.4.8            # via pylint
 click==6.6                # via flask
+coverage==4.4.2           # via pytest-cov
 Flask==0.11.1             # via pytest-flask
 flexmock==0.10.2
 freezegun==0.3.7
@@ -20,6 +21,7 @@ py==1.4.31                # via pytest
 pylint==1.6.4
 pytest-flask==0.10.0
 pytest==3.0.3
+pytest-cov==2.5.1
 python-dateutil==2.5.3    # via freezegun
 requests==2.11.1
 six==1.10.0               # via astroid, freezegun, pylint, python-dateutil


### PR DESCRIPTION
I tried to mimic setup made in other repositories (worker, jobs, ...) so the `Dockerfile.tests` used by tests, the script `runtest.sh`, and the script `hack/exec_tests.sh` are now very similar.