### PR TITLE
Update to include bumped selinon version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM registry.centos.org/centos/centos:7
 
 ENV LANG=en_US.UTF-8 \
-    F8A_WORKER_VERSION=379d32c
+    F8A_WORKER_VERSION=4b70a41
 
 RUN useradd -d /coreapi coreapi
 


### PR DESCRIPTION
Fixes this: https://github.com/fabric8-analytics/fabric8-analytics-server/issues/262