### PR TITLE
Use centos/postgresql-94-centos7 instead of sclo/postgresql-94-centos7

### DIFF
--- a/runtest.sh
+++ b/runtest.sh
@@ -15,7 +15,7 @@ DB_CONTAINER_NAME="db-server-tests-${TIMESTAMP}"
 CONTAINER_NAME="server-tests-${TIMESTAMP}"
 IMAGE_NAME=${IMAGE_NAME:-registry.devshift.net/bayesian/bayesian-api}
 TEST_IMAGE_NAME="coreapi-server-tests"
-POSTGRES_IMAGE_NAME="registry.centos.org/sclo/postgresql-94-centos7:latest"
+POSTGRES_IMAGE_NAME="registry.centos.org/centos/postgresql-94-centos7:latest"
 
 gc() {
   retval=$?


### PR DESCRIPTION
Fixes:
```
Starting/creating containers:
+ docker run -d --env-file tests/postgres.env --name db-server-tests-2018-03-02-06-29-59 registry.centos.org/sclo/postgresql-94-centos7:latest
Unable to find image 'registry.centos.org/sclo/postgresql-94-centos7:latest' locally
Trying to pull repository registry.centos.org/sclo/postgresql-94-centos7 ... 
Pulling repository registry.centos.org/sclo/postgresql-94-centos7
/usr/bin/docker-current: Error: image sclo/postgresql-94-centos7:latest not found.
```

Unlike https://registry.centos.org/centos/postgresql-94-centos7 the https://registry.centos.org/sclo/postgresql-94-centos7 is empty.

Not sure why we've been using the 'sclo' variant, but the tests run OK with the 'centos' one.