### PR TITLE
Install missing NPM package required by solver for package.json

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,6 +36,9 @@ RUN pushd /coreapi && \
 
 RUN pip3 install git+https://github.com/fabric8-analytics/fabric8-analytics-worker.git@${F8A_WORKER_VERSION}
 
+# Required by the solver task in worker to resolve dependencies from package.json
+RUN npm install -g semver-ranger
+
 COPY .git/ /tmp/.git
 # date and hash of last commit
 RUN cd /tmp/.git &&\


### PR DESCRIPTION
Server installs worker inside the container to perform dependency resolution on package.json files however in doing so it does not install the "non-pythonic" dependencies of the same. Without this package the dependency resolution for NPM was failing.

Signed-off-by: Avishkar Gupta <avgupta@redhat.com>