### PR TITLE
CI Trigger

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ about mismatched locations in compiled files. Those can be deleted using:
 
     $ find -name *.pyc -delete
 
-NOTE: Running the container based tests is likely to cause any already
+_NOTE_: Running the container based tests is likely to cause any already
 running local core API instance launched via Docker Compose to fall over due to
 changes in the SELinux labels on mounted volumes, and may also cause
 spurious test failures.


### PR DESCRIPTION
Due to the most unexpected of circumstances, CICO went down during the f8a-build -master (confirmed by the outage on status.centos.org) and CICO wasn't able to push the image to the devshift registry as can be seen here: https://ci.centos.org/job/devtools-fabric8-analytics-server-f8a-build-master/146/console, so updating readme to re-trigger the CI build master.