### PR TITLE
Deploy on RHEL based container

### DIFF
--- a/Dockerfile.rhel
+++ b/Dockerfile.rhel
@@ -1,0 +1,45 @@
+FROM prod.registry.devshift.net/osio-prod/base/fabric8-analytics-server:latest
+LABEL maintainer "Devtools <devtools@redhat.com>"
+LABEL author "Devtools <devtools@redhat.com>"
+
+ENV LANG=en_US.UTF-8 \
+    F8A_WORKER_VERSION=0fad8a2
+
+RUN useradd -d /coreapi coreapi
+
+COPY ./requirements.txt /coreapi/
+RUN pushd /coreapi && \
+    pip3 install -r requirements.txt && \
+    rm requirements.txt && \
+    popd
+
+COPY ./coreapi-httpd.conf /etc/httpd/conf.d/
+
+# Create & set pcp dirs
+RUN mkdir -p /etc/pcp /var/run/pcp /var/lib/pcp /var/log/pcp  && \
+    chgrp -R root /etc/pcp /var/run/pcp /var/lib/pcp /var/log/pcp && \
+    chmod -R g+rwX /etc/pcp /var/run/pcp /var/lib/pcp /var/log/pcp
+
+COPY ./ /coreapi
+RUN pushd /coreapi && \
+    pip3 install . && \
+    popd && \
+    # needed for DB migrations
+    find coreapi/ -mindepth 1 -maxdepth 1 \( ! -name 'alembic*' -a ! -name hack \) -exec rm -rf {} +
+
+RUN pip3 install git+https://github.com/fabric8-analytics/fabric8-analytics-worker.git@${F8A_WORKER_VERSION}
+
+# Required by the solver task in worker to resolve dependencies from package.json
+RUN npm install -g semver-ranger
+
+COPY .git/ /tmp/.git
+# date and hash of last commit
+RUN cd /tmp/.git &&\
+    git show -s --format="COMMITTED_AT=%ai%nCOMMIT_HASH=%h%n" HEAD | tee /etc/coreapi-release &&\
+    rm -rf /tmp/.git/
+
+COPY hack/coreapi-server.sh hack/server+pmcd.sh /usr/bin/
+
+EXPOSE 44321
+
+CMD ["/usr/bin/server+pmcd.sh"]

--- a/Makefile
+++ b/Makefile
@@ -2,18 +2,24 @@ REGISTRY?=registry.devshift.net
 REPOSITORY?=bayesian/bayesian-api
 DEFAULT_TAG=latest
 
+ifeq ($(TARGET),rhel)
+    DOCKERFILE := Dockerfile.rhel
+else
+    DOCKERFILE := Dockerfile
+endif
+
 .PHONY: all docker-build fast-docker-build test get-image-name get-image-repository docker-build-tests fast-docker-build-tests
 
 all: fast-docker-build
 
 docker-build:
-	docker build --no-cache -t $(REGISTRY)/$(REPOSITORY):$(DEFAULT_TAG) .
+	docker build --no-cache -t $(REGISTRY)/$(REPOSITORY):$(DEFAULT_TAG) -f $(DOCKERFILE) .
 
 docker-build-tests: docker-build
 	docker build --no-cache -t coreapi-server-tests -f Dockerfile.tests .
 
 fast-docker-build:
-	docker build -t $(REGISTRY)/$(REPOSITORY):$(DEFAULT_TAG) .
+	docker build -t $(REGISTRY)/$(REPOSITORY):$(DEFAULT_TAG) -f $(DOCKERFILE) .
 
 fast-docker-build-tests:
 	docker build -t coreapi-server-tests -f Dockerfile.tests .

--- a/cico_build_deploy.sh
+++ b/cico_build_deploy.sh
@@ -4,6 +4,9 @@ set -ex
 
 . cico_setup.sh
 
+# docker login before push is required for rhel build
+docker_login
+
 build_image
 
 IMAGE_NAME=$(make get-image-name) ./runtest.sh

--- a/cico_run_tests.sh
+++ b/cico_run_tests.sh
@@ -8,4 +8,5 @@ build_image
 
 IMAGE_NAME=$(make get-image-name) ./runtest.sh
 
+docker_login
 push_image


### PR DESCRIPTION
Enable build on RHEL if TARGET=rhel.

**These PRs need to merged before applying this one**:

- https://github.com/openshiftio/openshiftio-cico-jobs/pull/626
- https://github.com/openshiftio/saas-openshiftio/pull/821

As part of an effort to migrate the services running in OSIO from CentOS
to RHEL, we are ready to push out the RHEL based image for this service
into staging.

This PR includes a new RHEL based dockerfile for the deployment of the
service.
This dockerfile will be built when this variable is set: TARGET=rhel.
The build
scripts have been adapted to take this into consideration, and to push
the image
to different namespaces if the TARGET is rhel or not.

Currently the deployment builds happen on empty baremetal machines. The
build
script will be executed a second time to build and push the deployment
file if
TARGET=rhel, so some changes in the build script are to ensure that it
will work
if executed a second time.