### PR TITLE
Add pylist.json support for pypi service

### DIFF
--- a/bayesian/api_v1.py
+++ b/bayesian/api_v1.py
@@ -818,7 +818,7 @@ class StackAnalyses(ResourceWithSchema):
                 filepath = filepaths[index]
                 content = manifest_file_raw.read().decode('utf-8')
             # For npm-list.json, we need not verify it as its not going to mercator task
-            if origin != "vscode" and ecosystem != "npm":
+            if origin != "vscode" and ecosystem not in ("npm", "pypi"):
                 # check if manifest files with given name are supported
                 manifest_descriptor = get_manifest_descriptor_by_filename(filename)
                 if manifest_descriptor is None:
@@ -846,7 +846,7 @@ class StackAnalyses(ResourceWithSchema):
             api_url = current_app.config['F8_API_BACKBONE_HOST']
 
             d = DependencyFinder()
-            if origin == "vscode" and ecosystem == "npm":
+            if origin == "vscode" and ecosystem in ("npm", "pypi"):
                 deps = d.scan_and_find_dependencies(ecosystem, manifests)
             else:
                 deps = d.execute(args, rdb.session, manifests, source)

--- a/tests/data/manifests/pylist.json
+++ b/tests/data/manifests/pylist.json
@@ -1,0 +1,37 @@
+[
+    {
+        "deps": [
+            {
+                "package": "pytz",
+                "version": "2018.7"
+            }
+        ],
+        "package": "django",
+        "version": "2.1.3"
+    },
+    {
+        "deps": [],
+        "package": "numpy",
+        "version": "1.15.4"
+    },
+    {
+        "deps": [],
+        "package": "pyjwt",
+        "version": "1.6.4"
+    },
+    {
+        "deps": [
+            {
+                "package": "six",
+                "version": "1.11.0"
+            }
+        ],
+        "package": "python-dateutil",
+        "version": "2.7.5"
+    },
+    {
+        "deps": [],
+        "package": "pyyaml",
+        "version": "3.13"
+    }
+]

--- a/tests/test_depencency_finder.py
+++ b/tests/test_depencency_finder.py
@@ -17,5 +17,19 @@ def test_scan_and_find_dependencies():
     assert len(res['result'][0]['details'][0]['_resolved'][0]['deps']) == 2
 
 
+def test_scan_and_find_dependencies_pypi():
+    """Test scan_and_find_dependencies function for pypi."""
+    manifests = [{
+        "filename": "pylist.json",
+        "filepath": "/bin/local",
+        "content": open(str(Path(__file__).parent / "data/manifests/pylist.json")).read()
+    }]
+    res = DependencyFinder().scan_and_find_dependencies("pypi", manifests)
+    assert "result" in res
+    assert res['result'][0]['details'][0]['_resolved'][0]['package'] == "django"
+    assert len(res['result'][0]['details'][0]['_resolved'][0]['deps']) == 1
+
+
 if __name__ == '__main__':
     test_scan_and_find_dependencies()
+    test_scan_and_find_dependencies_pypi()


### PR DESCRIPTION
`pylist.json`:  file contains the python direct dependencies and transitive dependencies in the following format
```json
[
    {
        "package": "name",
        "version": "version",
        "deps": [
            {
                "package": "transitive 1",
                "version": "version"
            },
        ]
    },
]
```
this is the one-liner python script to generate the pylist.json file
```bash
python -c 'exec("""\nimport sys,json,pkg_resources as pr;a=set();b=set();rt=open(sys.argv[1]).readlines();gd=pr.get_distribution;rq=pr.require;res=list()\nfor i in rt:\n    try:\n        for j in rq(i):\n            J=(gd(j).key,gd(j).version);a.add(J)\n            for k in j.requires():\n                K=(gd(k).key,gd(k).version);b.add(K)\n    except:\n        pass\nfor i in rt:\n    try:\n        p=gd(i);d=(p.key,p.version)\n        if d in (a-b):\n            rs={}\n            rs["package"]=p.key\n            rs["version"]=p.version\n            rs["deps"]=set()\n            for j in pr.require(i):\n                t=(j.key,j.version)\n                if d != t and d in (a-b): rs["deps"].add(t)\n            rs["deps"]=[{"package":p,"version":v}for p, v in rs["deps"]];res.append(rs)\n    except:\n        pass\na=sys.argv[2:3]\nop=open(a[0],"w") if a else sys.stdout\njson.dump(res,op)\n""")' 
```
above python script requires two arguments 

_Args_: path/to/**requirements.txt**     path/to/**pylist.json**