### PR TITLE
Ecosystem Info added in Metrics Payload

### DIFF
--- a/bayesian/api_v1.py
+++ b/bayesian/api_v1.py
@@ -251,7 +251,10 @@ class ComponentAnalyses(Resource):
             "pid": os.getpid(),
             "hostname": HOSTNAME,
             "endpoint": request.endpoint,
-            "request_method": "GET"
+            "request_method": "GET",
+            "ecosystem": ecosystem,
+            "package": package,
+            "version": version
         }
         package = urllib.parse.unquote(package)
         if not check_for_accepted_ecosystem(ecosystem):


### PR DESCRIPTION
Information added in Metrics Payload which will be pushed to accumulator service.
Accumulator Needs this info for better logging in case of error occurs.