### PR TITLE
[APPAI-1295] Add environment variable to control the flow for unknown dependencies for component analyses

### DIFF
--- a/bayesian/api/api_v2.py
+++ b/bayesian/api/api_v2.py
@@ -116,12 +116,12 @@ class ComponentAnalysesApi(Resource):
         Component Analyses:
             - If package is Known (exists in GraphDB (Snyk Edge) returns Json formatted response.
             - If package is not Known:
-                - SKIP_UNKNOWN_PACKAGE_FLOW flag is up: Skips the unknow package and returns 404
-                - SKIP_UNKONWN_PACKAGE_FLOW flag is down: Than checks below condition.
-                    - INVOKE_API_WORKERS flag is up: Trigger bayesianApiFlow to fetch
-                                                     Package details
-                    - INVOKE_API_WORKERS flag is down: Trigger bayesianFlow to fetch
-                                                       Package details
+                - DISABLE_UNKNOWN_PACKAGE_FLOW flag is 1: Skips the unknown package and returns 202
+                - DISABLE_UNKONWN_PACKAGE_FLOW flag is 0: Than checks below condition.
+                    - INVOKE_API_WORKERS flag is 1: Trigger bayesianApiFlow to fetch
+                                                    Package details
+                    - INVOKE_API_WORKERS flag is 0: Trigger bayesianFlow to fetch
+                                                    Package details
 
         :return:
             JSON Response
@@ -164,14 +164,11 @@ class ComponentAnalysesApi(Resource):
             metrics_payload.update({"status_code": 200, "value": time.time() - st})
             _session.post(url=METRICS_SERVICE_URL + "/api/v1/prometheus", json=metrics_payload)
             return analyses_result
-        elif os.environ.get("SKIP_UNKNOWN_PACKAGE_FLOW", "") == "1":
+        elif os.environ.get("DISABLE_UNKNOWN_PACKAGE_FLOW", "") == "1":
             msg = f"No data found for {ecosystem} package {package}/{version} " \
-                   "and skip unknown package flow is enabled"
+                   "ingetion flow skipped as DISABLE_UNKNOWN_PACKAGE_FLOW is enabled"
 
-            metrics_payload.update({"status_code": 404, "value": time.time() - st})
-            _session.post(url=METRICS_SERVICE_URL + "/api/v1/prometheus", json=metrics_payload)
-
-            raise HTTPError(404, msg)
+            raise HTTPError(202, msg)
 
         if os.environ.get("INVOKE_API_WORKERS", "") == "1":
             # Trigger the unknown component ingestion.

--- a/bayesian/api/api_v2.py
+++ b/bayesian/api/api_v2.py
@@ -168,7 +168,7 @@ class ComponentAnalysesApi(Resource):
             msg = f"No data found for {ecosystem} package {package}/{version} " \
                    "ingetion flow skipped as DISABLE_UNKNOWN_PACKAGE_FLOW is enabled"
 
-            raise HTTPError(202, msg)
+            return response_template({'error': msg}, 202)
 
         if os.environ.get("INVOKE_API_WORKERS", "") == "1":
             # Trigger the unknown component ingestion.

--- a/bayesian/api_v1.py
+++ b/bayesian/api_v1.py
@@ -310,7 +310,7 @@ class ComponentAnalyses(Resource):
             msg = f"No data found for {ecosystem} package {package}/{version} " \
                    "ingetion flow skipped as DISABLE_UNKNOWN_PACKAGE_FLOW is enabled"
 
-            raise HTTPError(202, msg)
+            return {'error': msg}, 202
 
         if os.environ.get("INVOKE_API_WORKERS", "") == "1":
             # Enter the unknown path

--- a/bayesian/api_v1.py
+++ b/bayesian/api_v1.py
@@ -245,7 +245,21 @@ class ComponentAnalyses(Resource):
 
     @staticmethod
     def get(ecosystem, package, version):
-        """Handle the GET REST API call."""
+        """Handle the GET REST API call.
+
+        Component Analyses:
+            - If package is Known (exists in GraphDB) returns Json formatted response.
+            - If package is not Known:
+                - DISABLE_UNKNOWN_PACKAGE_FLOW flag is 1: Skips the unknown package and returns 202
+                - DISABLE_UNKONWN_PACKAGE_FLOW flag is 0: Than checks below condition.
+                    - INVOKE_API_WORKERS flag is 1: Trigger bayesianApiFlow to fetch
+                                                    Package details
+                    - INVOKE_API_WORKERS flag is 0: Trigger bayesianFlow to fetch
+                                                    Package details
+
+        :return:
+            JSON Response
+        """
         st = time.time()
         metrics_payload = {
             "pid": os.getpid(),
@@ -273,10 +287,16 @@ class ComponentAnalyses(Resource):
                 _session.post(url=METRICS_SERVICE_URL + "/api/v1/prometheus", json=metrics_payload)
                 raise HTTPError(400, msg)
 
-        package = case_sensitivity_transform(ecosystem, package)
-        # Querying GraphDB for CVE Info.
+        result = None
+        # Exception is raised when an unknown package is requested. Ignoring this with below
+        # try-except block as further flow takes care of unknown package flow.
+        try:
+            package = case_sensitivity_transform(ecosystem, package)
 
-        result = get_analyses_from_graph(ecosystem, package, version)
+            # Querying GraphDB for CVE Info.
+            result = get_analyses_from_graph(ecosystem, package, version)
+        except Exception as e:
+            current_app.logger.info(e)
 
         if result is not None:
             # Known component for Bayesian
@@ -286,6 +306,11 @@ class ComponentAnalyses(Resource):
             _session.post(url=METRICS_SERVICE_URL + "/api/v1/prometheus", json=metrics_payload)
 
             return result
+        elif os.environ.get("DISABLE_UNKNOWN_PACKAGE_FLOW", "") == "1":
+            msg = f"No data found for {ecosystem} package {package}/{version} " \
+                   "ingetion flow skipped as DISABLE_UNKNOWN_PACKAGE_FLOW is enabled"
+
+            raise HTTPError(202, msg)
 
         if os.environ.get("INVOKE_API_WORKERS", "") == "1":
             # Enter the unknown path

--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -63,7 +63,7 @@ objects:
                 key: sentry_dsn
           - name: INVOKE_API_WORKERS
             value: "1"
-          - name: SKIP_UNKNOWN_PACKAGE_FLOW
+          - name: DISABLE_UNKNOWN_PACKAGE_FLOW
             value: "0"
           - name: SHOW_TRANSITIVE_REPORT
             value: ${SHOW_TRANSITIVE_REPORT}

--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -63,6 +63,8 @@ objects:
                 key: sentry_dsn
           - name: INVOKE_API_WORKERS
             value: "1"
+          - name: SKIP_UNKNOWN_PACKAGE_FLOW
+            value: "0"
           - name: SHOW_TRANSITIVE_REPORT
             value: ${SHOW_TRANSITIVE_REPORT}
           - name: POSTGRESQL_DATABASE

--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -64,7 +64,7 @@ objects:
           - name: INVOKE_API_WORKERS
             value: "1"
           - name: DISABLE_UNKNOWN_PACKAGE_FLOW
-            value: "0"
+            value: ${DISABLE_UNKNOWN_PACKAGE_FLOW}
           - name: SHOW_TRANSITIVE_REPORT
             value: ${SHOW_TRANSITIVE_REPORT}
           - name: POSTGRESQL_DATABASE
@@ -199,6 +199,12 @@ parameters:
   required: false
   name: FLASK_LOGGING_LEVEL
   value: "WARNING"
+
+- description: Flag to enable or disable the unknown package ingetion flow
+  displayName: DISABLE UNKNOWN PACKAGE FLOW
+  required: false
+  name: DISABLE_UNKNOWN_PACKAGE_FLOW
+  value: "0"
 
 - description: Flag to enable or disable the transitive report from stack report
   displayName: SHOW TRANSITIVE REPORT

--- a/tests/api/test_api_v2.py
+++ b/tests/api/test_api_v2.py
@@ -101,7 +101,9 @@ class TestComponentAnalysesApi(unittest.TestCase):
         """No Analyses Data found, with DISABLE_UNKNOWN_PACKAGE_FLOW flag, Raises HTTP Error."""
         with patch.dict('os.environ', {'DISABLE_UNKNOWN_PACKAGE_FLOW': '1'}):
             ca = ComponentAnalysesApi()
-            self.assertRaises(HTTPError, ca.get, 'npm', 'pkg', 'ver')
+            response = ca.get('npm', 'pkg', 'ver')
+            self.assertEqual(response.status, 202)
+            self.assertIsInstance(response, tuple)
 
     @patch('bayesian.api.api_v2.g')
     @patch('bayesian.api.api_v2._session')

--- a/tests/api/test_api_v2.py
+++ b/tests/api/test_api_v2.py
@@ -95,14 +95,13 @@ class TestComponentAnalysesApi(unittest.TestCase):
     @patch('bayesian.api.api_v2.server_create_analysis')
     @patch('bayesian.api.api_v2.request')
     @patch('bayesian.api.api_v2.case_sensitivity_transform')
-    def test_get_component_analyses_with_skip_unknown_package_flow(self, _sensitive, _request,
-                                                                   _analyses, _bookkeeping,
-                                                                   _session, _g):
-        """No Analyses Data found, with SKIP_UNKNOWN_PACKAGE_FLOW flag, Raises HTTP Error."""
-        with patch.dict('os.environ', {'SKIP_UNKNOWN_PACKAGE_FLOW': '1'}):
+    def test_get_component_analyses_with_disable_unknown_package_flow(self, _sensitive, _request,
+                                                                      _analyses, _bookkeeping,
+                                                                      _session, _g):
+        """No Analyses Data found, with DISABLE_UNKNOWN_PACKAGE_FLOW flag, Raises HTTP Error."""
+        with patch.dict('os.environ', {'DISABLE_UNKNOWN_PACKAGE_FLOW': '1'}):
             ca = ComponentAnalysesApi()
             self.assertRaises(HTTPError, ca.get, 'npm', 'pkg', 'ver')
-        self.assertNotIn('SKIP_UNKNOWN_PACKAGE_FLOW', os.environ)
 
     @patch('bayesian.api.api_v2.g')
     @patch('bayesian.api.api_v2._session')

--- a/tests/api/test_api_v2.py
+++ b/tests/api/test_api_v2.py
@@ -95,6 +95,21 @@ class TestComponentAnalysesApi(unittest.TestCase):
     @patch('bayesian.api.api_v2.server_create_analysis')
     @patch('bayesian.api.api_v2.request')
     @patch('bayesian.api.api_v2.case_sensitivity_transform')
+    def test_get_component_analyses_with_skip_unknown_package_flow(self, _sensitive, _request,
+                                                                   _analyses, _bookkeeping,
+                                                                   _session, _g):
+        """No Analyses Data found, with SKIP_UNKNOWN_PACKAGE_FLOW flag, Raises HTTP Error."""
+        with patch.dict('os.environ', {'SKIP_UNKNOWN_PACKAGE_FLOW': '1'}):
+            ca = ComponentAnalysesApi()
+            self.assertRaises(HTTPError, ca.get, 'npm', 'pkg', 'ver')
+        self.assertNotIn('SKIP_UNKNOWN_PACKAGE_FLOW', os.environ)
+
+    @patch('bayesian.api.api_v2.g')
+    @patch('bayesian.api.api_v2._session')
+    @patch('bayesian.api.api_v2.server_create_component_bookkeeping')
+    @patch('bayesian.api.api_v2.server_create_analysis')
+    @patch('bayesian.api.api_v2.request')
+    @patch('bayesian.api.api_v2.case_sensitivity_transform')
     def test_get_component_analyses(self, _sensitive, _request,
                                     _analyses, _bookkeeping, _session, _g):
         """CA GET: No Analyses Data found, without INVOKE_API_WORKERS flag, Raises HTTP Error."""

--- a/tests/test_api_v1.py
+++ b/tests/test_api_v1.py
@@ -5,6 +5,7 @@ import io
 from pathlib import Path
 import pytest
 import json
+from unittest.mock import patch
 from bayesian import api_v1
 from f8a_worker.enums import EcosystemBackend
 from f8a_worker.models import Analysis, Ecosystem, Package, Version, WorkerResult
@@ -209,6 +210,13 @@ class TestCommonEndpoints(object):
         res = self.client.get(api_route_for('/component-analyses/abb/cc/dd'),
                               headers=accept_json)
         assert res.status_code == 400
+
+    def test_component_analyses_disable_unknown_package_flow(self, accept_json):
+        """Test the /component-analyses endpoint for GET."""
+        with patch.dict('os.environ', {'DISABLE_UNKNOWN_PACKAGE_FLOW': '1'}):
+            res = self.client.get(api_route_for('/component-analyses/npm/server-unknown/1.7.1'),
+                                  headers=accept_json)
+            assert res.status_code == 202
 
     def test_component_analyses1(self):
         """Test the /component-analyses endpoint for POST."""


### PR DESCRIPTION
We need a way to control the unknown package API flow during e2e testing. This PR added a new environment variable 'DISABLE_UNKNOWN_PACKAGE_FLOW' to be enabled on staging to avoid the unknown package API flow for component analyses request.

Jira issue: https://issues.redhat.com/browse/APPAI-1295