### PR TITLE
[APPAI-1330] Sentry shouldn't show HTTP status 202 as error

### DIFF
--- a/bayesian/api/api_v2.py
+++ b/bayesian/api/api_v2.py
@@ -228,7 +228,8 @@ class StackAnalysesApi(Resource):
         except RDBServerException as e:
             raise HTTPError(500, e.args[0]) from e
         except SARBRequestInprogressException as e:
-            raise HTTPError(202, e.args[0]) from e
+            # Request is in progress is not error, so lets not raise exception.
+            return {'error': e.args[0]}, 202
         except SARBRequestTimeoutException as e:
             raise HTTPError(408, e.args[0]) from e
 


### PR DESCRIPTION
Avoid reporting 202 to sentry.

Jira Issue: https://issues.redhat.com/browse/APPAI-1330