### PR TITLE
removed get_version_without_cves method in ca

### DIFF
--- a/bayesian/utility/v2/ca_response_builder.py
+++ b/bayesian/utility/v2/ca_response_builder.py
@@ -18,7 +18,6 @@
 from urllib.parse import quote
 import logging
 from bayesian.utility.db_gateway import GraphAnalyses
-from bayesian.utils import version_info_tuple, convert_version_to_proper_semantic
 
 logger = logging.getLogger(__file__)
 
@@ -109,7 +108,7 @@ class ComponentAnalysisResponseBuilder:
         if (not self.has_cves()) or not bool(latest_non_cve_versions):
             # If Package has No cves or No Latest Non CVE Versions.
             return dict(recommendation={})
-        self.nocve_version = self.get_version_without_cves(latest_non_cve_versions)
+        self.nocve_version = latest_non_cve_versions
         self.public_vul, self.pvt_vul = self.get_vulnerabilities_count()
         self.severity = self.get_severity()
         return self.generate_response()
@@ -166,33 +165,6 @@ class ComponentAnalysisResponseBuilder:
 
         message = f'Recommendation: use version {self.nocve_version}.'
         return message
-
-    def get_version_without_cves(self, latest_non_cve_versions):
-        """Return higher version which doesn't have any CVEs. None if there is no such version.
-
-        :return: Highest Version out of all latest_non_cve_versions.
-        """
-        logger.info("All Versions with Vulnerabilities.")
-        input_version_tuple = version_info_tuple(
-            convert_version_to_proper_semantic(self.version)
-        )
-        highest_version = ''
-        for version in latest_non_cve_versions:
-
-            graph_version_tuple = version_info_tuple(
-                convert_version_to_proper_semantic(version)
-            )
-            if graph_version_tuple > input_version_tuple:
-                if not highest_version:
-                    highest_version = version
-                highest_version_tuple = version_info_tuple(
-                    convert_version_to_proper_semantic(highest_version)
-                )
-                # If version to recommend is closer to what a user is using then, use less than
-                # If recommendation is to show highest version then, use greater than
-                if graph_version_tuple > highest_version_tuple:
-                    highest_version = version
-        return highest_version
 
     def has_cves(self):
         """Check if package has Vulnerability.

--- a/tests/utility/v2/test_ca_response_builder.py
+++ b/tests/utility/v2/test_ca_response_builder.py
@@ -113,12 +113,10 @@ class ComponentAnalysisResponseBuilderTest(unittest.TestCase):
     @patch('bayesian.utility.v2.ca_response_builder'
            '.ComponentAnalysisResponseBuilder.get_vulnerabilities_count')
     @patch('bayesian.utility.v2.ca_response_builder'
-           '.ComponentAnalysisResponseBuilder.get_version_without_cves')
-    @patch('bayesian.utility.v2.ca_response_builder'
            '.ComponentAnalysisResponseBuilder.get_cve_maps', return_value=[])
     @patch('bayesian.utility.v2.ca_response_builder'
            '.ComponentAnalysisResponseBuilder.has_cves', return_value=True)
-    def test_generate_recommendation_same_version(self, _hascve, _cvemaps, _nocve,
+    def test_generate_recommendation_same_version(self, _hascve, _cvemaps,
                                                   _vulcount, _severity, _response):
         """Test Function for Generate recommendation_same_version."""
         _vulcount.return_value = (0, 0)
@@ -184,18 +182,6 @@ class ComponentAnalysisResponseBuilderTest(unittest.TestCase):
                     "security advisory with 1 having high severity. " \
                     "No recommended version."
         self.assertEqual(message, ideal_msg)
-
-    def test_get_version_without_cves(self):
-        """Test Get version without cves."""
-        response_obj = ComponentAnalysisResponseBuilder(self.eco, self.pkg, self.ver)
-        version = response_obj.get_version_without_cves(['1.1'])
-        self.assertEqual(version, '1.1')
-
-    def test_get_version_without_cves_highest(self):
-        """Test Get highest version without cves."""
-        response_obj = ComponentAnalysisResponseBuilder(self.eco, self.pkg, self.ver)
-        version = response_obj.get_version_without_cves(['2', '3'])
-        self.assertEqual(version, '3')
 
     @patch('bayesian.utility.v2.ca_response_builder.'
            'ComponentAnalysisResponseBuilder.get_cve_maps')


### PR DESCRIPTION
Removed `get_version_without_cves` from CA.

Signed-off-by: Deepak Sharma <deepshar@redhat.com>