### PR TITLE
[APPAI-1387] [API Server] Unify logging using root logger

### DIFF
--- a/bayesian/__init__.py
+++ b/bayesian/__init__.py
@@ -18,10 +18,17 @@ def setup_logging(app):
     """Set up logger, the log level is read from the environment variable."""
     if not app.debug:
         handler = logging.StreamHandler()
+        handler.setFormatter(logging.Formatter(
+            '[%(asctime)s] %(levelname)s in %(pathname)s:%(lineno)d: %(message)s'))
         log_level = os.environ.get('FLASK_LOGGING_LEVEL', logging.getLevelName(logging.WARNING))
         handler.setLevel(log_level)
         app.logger.addHandler(handler)
 
+
+# Set root logger format for uniform log format.
+log_level = os.environ.get('FLASK_LOGGING_LEVEL', logging.getLevelName(logging.WARNING))
+logging.basicConfig(level=log_level,
+                    format='[%(asctime)s] %(levelname)s in %(pathname)s:%(lineno)d: %(message)s')
 
 # we must initialize DB here to not create import loop with .auth...
 #  flask really sucks at this

--- a/bayesian/api/api_v2.py
+++ b/bayesian/api/api_v2.py
@@ -80,14 +80,12 @@ logger = logging.getLogger(__name__)
 @api_v2.route('/readiness')
 def readiness():
     """Handle the /readiness REST API call."""
-    logger.debug('/readiness endpoint accessed')
     return jsonify({}), 200
 
 
 @api_v2.route('/liveness')
 def liveness():
     """Handle the /liveness REST API call."""
-    logger.debug('/liveness endpoint accessed')
     return jsonify({}), 200
 
 
@@ -210,7 +208,7 @@ class ComponentAnalysesApi(Resource):
 def stack_analyses_with_request_id(external_request_id):
     """Handle stack analyses report fetch api."""
     start = time.time()
-    logger.debug("[GET] /stack-analyses/{}".format(external_request_id))
+    logger.debug("[GET] /stack-analyses/%s", external_request_id)
 
     # 1. Build response builder with id and RDB object.
     sa_response_builder = StackAnalysesResponseBuilder(external_request_id,
@@ -219,8 +217,8 @@ def stack_analyses_with_request_id(external_request_id):
     # 2. If there was no exception raise, means request is ready to be served.
     try:
         data = sa_response_builder.get_response()
-        logger.info('{r} took {t:.2f} seconds for [GET] stack-analyses'.format(
-            r=external_request_id, t=time.time() - start))
+        logger.info('%s took %f seconds for [GET] stack-analyses',
+                    external_request_id, time.time() - start)
         return jsonify(data)
     except SARBRequestInvalidException as e:
         raise HTTPError(400, e.args[0]) from e
@@ -242,7 +240,7 @@ def stack_analyses():
 
     GET method would raise error to provide missing request id to the user.
     """
-    logger.debug("[{}] /stack-analyses accessed".format(request.method))
+    logger.debug('[%s] /stack-analyses accessed', request.method)
     start = time.time()
     if request.method == 'GET':
         raise HTTPError(400, error="Request id missing")
@@ -266,8 +264,8 @@ def stack_analyses():
     # 4. Post request
     try:
         data = sa.post_request()
-        logger.info('{r} took {t:.2f} seconds for [POST] stack-analyses'.format(
-            r=data['id'], t=time.time() - start))
+        logger.info('%s took %f seconds for [POST] stack-analyses',
+                    data['id'], time.time() - start)
         return jsonify(data)
     except SAInvalidInputException as e:
         raise HTTPError(400, e.args[0]) from e

--- a/bayesian/api_v1.py
+++ b/bayesian/api_v1.py
@@ -1066,7 +1066,7 @@ class CoreDependencies(Resource):
             }
             return response, 200
         except Exception as e:
-            logger.error('ERROR: {}'.format(str(e)))
+            logger.error('ERROR: %s', str(e))
 
 
 class EmptyBooster(Resource):
@@ -1186,7 +1186,7 @@ class CveByDateEcosystem(Resource):
                                              modified_date, ecosystem, date_range)
             result = getcve.get_cves_by_date_ecosystem()
         except Exception as e:
-            logger.error('ERROR: {}'.format(str(e)))
+            logger.error('ERROR: %s', str(e))
             msg = "No cve data found for {ecosystem} ".format(ecosystem=ecosystem)
             raise HTTPError(404, msg)
 
@@ -1205,7 +1205,7 @@ class EpvsByCveidService(Resource):
             getcve = CveByDateEcosystemUtils(cve_id)
             result = getcve.get_cves_epv_by_date()
         except Exception as e:
-            logger.error('ERROR: {}'.format(str(e)))
+            logger.error('ERROR: %s', str(e))
             msg = "No epv data found for {cve_id} ".format(cve_id=cve_id)
             raise HTTPError(404, msg)
 

--- a/bayesian/api_v1.py
+++ b/bayesian/api_v1.py
@@ -298,7 +298,7 @@ class ComponentAnalyses(Resource):
             # Querying GraphDB for CVE Info.
             result = get_analyses_from_graph(ecosystem, package, version)
         except Exception as e:
-            logger.info(e)
+            logger.error('ERROR: %s', str(e))
 
         if result is not None:
             # Known component for Bayesian
@@ -812,8 +812,7 @@ class StackAnalyses(Resource):
                 filepaths = request.values.getlist('filePath[]')
                 license_files = request.files.getlist('license[]')
 
-                logger.info('%r' % files)
-                logger.info('%r' % filepaths)
+                logger.info('files: %s filepaths: %s', files, filepaths)
 
                 # At least one manifest file path should be present to analyse a stack
                 if not filepaths:

--- a/bayesian/api_v1.py
+++ b/bayesian/api_v1.py
@@ -114,7 +114,7 @@ def readiness():
 def liveness():
     """Handle the /liveness REST API call."""
     # Check database connection
-    logger.debug("Liveness probe - trying to connect to database and execute a query")
+    logger.debug('Liveness probe - trying to connect to database and execute a query')
     rdb.session.query(Ecosystem).count()
     return jsonify({}), 200
 
@@ -990,8 +990,7 @@ class SubmitFeedback(Resource):
             return {'status': 'success'}
         except SQLAlchemyError as e:
             # TODO: please log the actual error too here
-            logger.exception(
-                'Failed to create new analysis request')
+            logger.exception('Failed to create new analysis request')
             raise HTTPError(
                 500, "Error inserting log for request {t}".format(t=stack_id)) from e
 

--- a/bayesian/api_v1.py
+++ b/bayesian/api_v1.py
@@ -12,6 +12,7 @@ import time
 from collections import defaultdict
 
 import botocore
+import logging
 from requests_futures.sessions import FuturesSession
 from flask import Blueprint, current_app, request, url_for, Response, g
 from flask.json import jsonify
@@ -50,6 +51,8 @@ from .generate_manifest import PomXMLTemplate
 from .default_config import COMPONENT_ANALYSES_LIMIT
 from fabric8a_auth.errors import AuthError
 
+
+logger = logging.getLogger(__name__)
 
 # TODO: improve maintainability index
 # TODO: https://github.com/fabric8-analytics/fabric8-analytics-server/issues/373
@@ -111,8 +114,7 @@ def readiness():
 def liveness():
     """Handle the /liveness REST API call."""
     # Check database connection
-    current_app.logger.debug("Liveness probe - trying to connect to database "
-                             "and execute a query")
+    logger.debug("Liveness probe - trying to connect to database and execute a query")
     rdb.session.query(Ecosystem).count()
     return jsonify({}), 200
 
@@ -296,7 +298,7 @@ class ComponentAnalyses(Resource):
             # Querying GraphDB for CVE Info.
             result = get_analyses_from_graph(ecosystem, package, version)
         except Exception as e:
-            current_app.logger.info(e)
+            logger.info(e)
 
         if result is not None:
             # Known component for Bayesian
@@ -634,7 +636,7 @@ class UserIntentGET(Resource):
         except botocore.exceptions.ClientError:
             err_msg = "Failed to fetch data for the user {u}, ecosystem {e}".format(u=user,
                                                                                     e=ecosystem)
-            current_app.logger.exception(err_msg)
+            logger.exception(err_msg)
             raise HTTPError(404, error=err_msg)
 
         return result
@@ -663,7 +665,7 @@ class MasterTagsGET(Resource):
             result = s3.fetch_master_tags(ecosystem)
         except botocore.exceptions.ClientError:
             err_msg = "Failed to fetch master tags for the ecosystem {e}".format(e=ecosystem)
-            current_app.logger.exception(err_msg)
+            logger.exception(err_msg)
             raise HTTPError(404, error=err_msg)
 
         return result
@@ -810,8 +812,8 @@ class StackAnalyses(Resource):
                 filepaths = request.values.getlist('filePath[]')
                 license_files = request.files.getlist('license[]')
 
-                current_app.logger.info('%r' % files)
-                current_app.logger.info('%r' % filepaths)
+                logger.info('%r' % files)
+                logger.info('%r' % filepaths)
 
                 # At least one manifest file path should be present to analyse a stack
                 if not filepaths:
@@ -988,7 +990,7 @@ class SubmitFeedback(Resource):
             return {'status': 'success'}
         except SQLAlchemyError as e:
             # TODO: please log the actual error too here
-            current_app.logger.exception(
+            logger.exception(
                 'Failed to create new analysis request')
             raise HTTPError(
                 500, "Error inserting log for request {t}".format(t=stack_id)) from e
@@ -1064,7 +1066,7 @@ class CoreDependencies(Resource):
             }
             return response, 200
         except Exception as e:
-            current_app.logger.error('ERROR: {}'.format(str(e)))
+            logger.error('ERROR: {}'.format(str(e)))
 
 
 class EmptyBooster(Resource):
@@ -1184,7 +1186,7 @@ class CveByDateEcosystem(Resource):
                                              modified_date, ecosystem, date_range)
             result = getcve.get_cves_by_date_ecosystem()
         except Exception as e:
-            current_app.logger.error('ERROR: {}'.format(str(e)))
+            logger.error('ERROR: {}'.format(str(e)))
             msg = "No cve data found for {ecosystem} ".format(ecosystem=ecosystem)
             raise HTTPError(404, msg)
 
@@ -1203,7 +1205,7 @@ class EpvsByCveidService(Resource):
             getcve = CveByDateEcosystemUtils(cve_id)
             result = getcve.get_cves_epv_by_date()
         except Exception as e:
-            current_app.logger.error('ERROR: {}'.format(str(e)))
+            logger.error('ERROR: {}'.format(str(e)))
             msg = "No epv data found for {cve_id} ".format(cve_id=cve_id)
             raise HTTPError(404, msg)
 

--- a/bayesian/auth.py
+++ b/bayesian/auth.py
@@ -1,8 +1,12 @@
 """Authorization token handling."""
-from flask import current_app, request
+import logging
+from flask import request
 from requests import get
 
 from .default_config import AUTH_URL
+
+
+logger = logging.getLogger(__name__)
 
 
 def get_access_token(service_name):
@@ -21,4 +25,4 @@ def get_access_token(service_name):
             return {"access_token": None}
 
     except Exception:
-        current_app.logger.error("Unable to connect to Auth service")
+        logger.error("Unable to connect to Auth service")

--- a/bayesian/auth.py
+++ b/bayesian/auth.py
@@ -25,4 +25,4 @@ def get_access_token(service_name):
             return {"access_token": None}
 
     except Exception:
-        logger.error("Unable to connect to Auth service")
+        logger.error('Unable to connect to Auth service')

--- a/bayesian/dependency_finder.py
+++ b/bayesian/dependency_finder.py
@@ -96,7 +96,7 @@ class DependencyFinder():
         try:
             versions = solver.solve(deps)
         except Exception:
-            logger.error("Dependencies could not be resolved: '{}'" .format(deps))
+            logger.error("Dependencies could not be resolved: '%s'", deps)
             raise
         return [{"package": k, "version": v} for k, v in versions.items()]
 
@@ -211,7 +211,7 @@ class DependencyFinder():
         if ecosystem == 'pypi' or ecosystem == 'golang':
             if not content:
                 logger.warning(
-                    "No content provided for manifest file {}".format(manifest['filename']))
+                    "No content provided for manifest file %s", manifest['filename'])
             if type(content) != list:
                 raise HTTPError(400, "manifest file must be in the format of "
                                 "[{package: name, version: ver, deps: []}, ]")

--- a/bayesian/dependency_finder.py
+++ b/bayesian/dependency_finder.py
@@ -96,7 +96,7 @@ class DependencyFinder():
         try:
             versions = solver.solve(deps)
         except Exception:
-            logger.error("Dependencies could not be resolved: '%s'", deps)
+            logger.error('Dependencies could not be resolved: "%s"', deps)
             raise
         return [{"package": k, "version": v} for k, v in versions.items()]
 
@@ -109,14 +109,14 @@ class DependencyFinder():
             content_hash = None
             if source == 'osio':
                 content_hash = generate_content_hash(manifest['content'])
-                logger.info("{} file digest is {}".format(manifest['filename'], content_hash))
+                logger.info('%s file digest is %s', manifest['filename'], content_hash)
 
                 s3 = AmazonS3(bucket_name='boosters-manifest')
                 try:
                     s3.connect()
                     manifest['content'] = s3.retrieve_blob(content_hash).decode('utf-8')
                 except ClientError as e:
-                    logger.error("Unexpected error while retrieving S3 data: %s" % e)
+                    logger.error('Unexpected error while retrieving S3 data: %s', e)
                     raise
 
             with TemporaryDirectory() as temp_path:
@@ -210,8 +210,7 @@ class DependencyFinder():
         content = json.loads(manifest['content'])
         if ecosystem == 'pypi' or ecosystem == 'golang':
             if not content:
-                logger.warning(
-                    "No content provided for manifest file %s", manifest['filename'])
+                logger.warning('No content provided for manifest file %s', manifest['filename'])
             if type(content) != list:
                 raise HTTPError(400, "manifest file must be in the format of "
                                 "[{package: name, version: ver, deps: []}, ]")

--- a/bayesian/license_extractor.py
+++ b/bayesian/license_extractor.py
@@ -8,7 +8,6 @@ from .default_config import LIC_SYNONYMS_URL
 from requests import get
 from collections import defaultdict
 from lru import lru_cache_function
-from datetime import datetime as dt
 
 
 logger = logging.getLogger(__name__)
@@ -20,12 +19,10 @@ def get_license_synonyms():
     """Fetch all the license sysnonyms from license anlysis github repo."""
     resp = get(LIC_SYNONYMS_URL)
     if resp.status_code == 200:
-        logger.info(
-            "{} Succefully fetched license synonyms".format(dt.now()))
+        logger.info('Succefully fetched license synonyms')
         return resp.json()
     else:
-        logger.error("{tm} Unable to fetch license synonyms, STATUS_CODE:{cd}".format(
-            tm=dt.now(), cd=resp.status_code))
+        logger.error('Unable to fetch license synonyms, STATUS_CODE: %d', resp.status_code)
         return {}
 
 
@@ -63,7 +60,7 @@ def extract_licenses(license_files):
                         license_key = max(_temp, key=len)
                 response[f_no] = lic_syn.get(license_key, 'unknown')
             except Exception as e:
-                logger.error('{time} {msg}'.format(time=dt.now(), msg=str(e)))
+                logger.error('ERROR: %s', str(e))
     else:
         get_license_synonyms.cache.clear()
     return response

--- a/bayesian/license_extractor.py
+++ b/bayesian/license_extractor.py
@@ -3,12 +3,15 @@
 
 """License extractor utility functions."""
 
+import logging
 from .default_config import LIC_SYNONYMS_URL
 from requests import get
 from collections import defaultdict
 from lru import lru_cache_function
-from flask import current_app
 from datetime import datetime as dt
+
+
+logger = logging.getLogger(__name__)
 
 
 # caching response for 24 hours
@@ -17,11 +20,11 @@ def get_license_synonyms():
     """Fetch all the license sysnonyms from license anlysis github repo."""
     resp = get(LIC_SYNONYMS_URL)
     if resp.status_code == 200:
-        current_app.logger.info(
+        logger.info(
             "{} Succefully fetched license synonyms".format(dt.now()))
         return resp.json()
     else:
-        current_app.logger.error("{tm} Unable to fetch license synonyms, STATUS_CODE:{cd}".format(
+        logger.error("{tm} Unable to fetch license synonyms, STATUS_CODE:{cd}".format(
             tm=dt.now(), cd=resp.status_code))
         return {}
 
@@ -60,7 +63,7 @@ def extract_licenses(license_files):
                         license_key = max(_temp, key=len)
                 response[f_no] = lic_syn.get(license_key, 'unknown')
             except Exception as e:
-                current_app.logger.error('{time} {msg}'.format(time=dt.now(), msg=str(e)))
+                logger.error('{time} {msg}'.format(time=dt.now(), msg=str(e)))
     else:
         get_license_synonyms.cache.clear()
     return response

--- a/bayesian/utility/db_gateway.py
+++ b/bayesian/utility/db_gateway.py
@@ -67,10 +67,9 @@ class GraphAnalyses:
                 'version': version
             }
         }
-        logger.debug("Executing Gremlin calls with payload {}".format(payload))
+        logger.debug('Executing Gremlin calls with payload %s', payload)
         query_result = post(gremlin_url, data=json.dumps(payload))
-        elapsed_seconds = (datetime.now() - start).total_seconds()
-        logger.info("Gremlin request took {} seconds.".format(elapsed_seconds))
+        logger.info('Gremlin request took %f seconds', (datetime.now() - start).total_seconds())
         return query_result.json()
 
 
@@ -93,8 +92,7 @@ class RdbAnalyses:
         try:
             start = time.time()
             db_result = fetch_sa_request(rdb, self.request_id)
-            logger.info('{r} took {t:.2f} seconds to fetch data'.format(
-                r=self.request_id, t=time.time() - start))
+            logger.info('%s took %f seconds to fetch data', self.request_id, time.time() - start)
         except Exception as e:
             error_message = 'Internal database server error for {}.'.format(self.request_id)
             logger.exception(error_message)
@@ -131,11 +129,10 @@ class RdbAnalyses:
             )
             rdb.session.execute(do_update_stmt)
             rdb.session.commit()
-            logger.info('{r} took {t:.2f} seconds to save data'.format(
-                r=self.request_id, t=time.time() - start))
+            logger.info('%s took %f seconds to save data', self.request_id, time.time() - start)
         except SQLAlchemyError as e:
-            logger.exception("Error updating log for request {}, exception {}".format(
-                self.request_id, e))
+            logger.exception('%s Error updating log, exception %s',
+                             self.request_id, str(e))
             raise RDBSaveException('Error while saving request {}'.format(self.request_id)) from e
 
 

--- a/bayesian/utility/db_gateway.py
+++ b/bayesian/utility/db_gateway.py
@@ -131,8 +131,7 @@ class RdbAnalyses:
             rdb.session.commit()
             logger.info('%s took %f seconds to save data', self.request_id, time.time() - start)
         except SQLAlchemyError as e:
-            logger.exception('%s Error updating log, exception %s',
-                             self.request_id, str(e))
+            logger.exception('%s Error updating log, exception %s', self.request_id, str(e))
             raise RDBSaveException('Error while saving request {}'.format(self.request_id)) from e
 
 

--- a/bayesian/utility/user_utils.py
+++ b/bayesian/utility/user_utils.py
@@ -11,7 +11,7 @@ from sqlalchemy import insert, update
 from f8a_worker.models import (UserDetails)
 from bayesian import rdb
 
-logger = logging.getLogger(__file__)
+logger = logging.getLogger(__name__)
 
 
 @retry(reraise=True, stop=tenacity.stop_after_attempt(3), wait=tenacity.wait_fixed(1))

--- a/bayesian/utility/v2/backbone_server.py
+++ b/bayesian/utility/v2/backbone_server.py
@@ -17,10 +17,11 @@
 """Backbone server interface to be used by stack analyses API v2 flow."""
 
 import os
+import time
 import logging
 from requests_futures.sessions import FuturesSession
 
-logger = logging.getLogger(__file__)
+logger = logging.getLogger(__name__)
 
 
 class BackboneServer:
@@ -44,10 +45,13 @@ class BackboneServer:
                 cls.backbone_host, body, params))
 
             # Post Backbone stack_aggregator call.
+            start = time.time()
             BackboneServer.session.post(
                 '{}/api/v2/stack_aggregator'.format(BackboneServer.backbone_host),
                 json=body,
                 params=params)
+            logger.debug('{r} took {t:.2f} seconds for /api/v2/stack_aggregator'.format(
+                r=body['external_request_id'], t=time.time() - start))
         except Exception as e:
             logger.exception('Aggregator api throws exception {}'.format(e))
             raise BackboneServerException('Error while reaching aggregator service') from e
@@ -60,10 +64,13 @@ class BackboneServer:
                 cls.backbone_host, body, params))
 
             # Post Backbone recommender call.
+            start = time.time()
             BackboneServer.session.post(
                 '{}/api/v2/recommender'.format(BackboneServer.backbone_host),
                 json=body,
                 params=params)
+            logger.debug('{r} took {t:.2f} seconds for /api/v2/recommender'.format(
+                r=body['external_request_id'], t=time.time() - start))
         except Exception as e:
             logger.exception('Recommender api throws exception {}'.format(e))
             raise BackboneServerException('Error while reaching recommender service') from e

--- a/bayesian/utility/v2/backbone_server.py
+++ b/bayesian/utility/v2/backbone_server.py
@@ -41,8 +41,8 @@ class BackboneServer:
     def post_aggregate_request(cls, body, params):
         """Make a post call to backbone aggregator api."""
         try:
-            logger.debug('Aggregator request for backbone host: {} body: {} params: {}'.format(
-                cls.backbone_host, body, params))
+            logger.debug('Aggregator request for backbone host: %s body: %s params: %s',
+                         cls.backbone_host, body, params)
 
             # Post Backbone stack_aggregator call.
             start = time.time()
@@ -50,18 +50,18 @@ class BackboneServer:
                 '{}/api/v2/stack_aggregator'.format(BackboneServer.backbone_host),
                 json=body,
                 params=params)
-            logger.debug('{r} took {t:.2f} seconds for /api/v2/stack_aggregator'.format(
-                r=body['external_request_id'], t=time.time() - start))
+            logger.debug('%s took %f seconds for /api/v2/stack_aggregator',
+                         body['external_request_id'], time.time() - start)
         except Exception as e:
-            logger.exception('Aggregator api throws exception {}'.format(e))
+            logger.exception('Aggregator api throws exception %s', str(e))
             raise BackboneServerException('Error while reaching aggregator service') from e
 
     @classmethod
     def post_recommendations_request(cls, body, params):
         """Make a post call to backbone recommender api."""
         try:
-            logger.debug('Recmmendation request for backbone host: {} body: {} params: {}'.format(
-                cls.backbone_host, body, params))
+            logger.debug('Recommendation request for backbone host: %s body: %s params: %s',
+                         cls.backbone_host, body, params)
 
             # Post Backbone recommender call.
             start = time.time()
@@ -69,10 +69,10 @@ class BackboneServer:
                 '{}/api/v2/recommender'.format(BackboneServer.backbone_host),
                 json=body,
                 params=params)
-            logger.debug('{r} took {t:.2f} seconds for /api/v2/recommender'.format(
-                r=body['external_request_id'], t=time.time() - start))
+            logger.debug('%s took %f seconds for /api/v2/recommender',
+                         body['external_request_id'], time.time() - start)
         except Exception as e:
-            logger.exception('Recommender api throws exception {}'.format(e))
+            logger.exception('Recommender api throws exception %s', str(e))
             raise BackboneServerException('Error while reaching recommender service') from e
 
 

--- a/bayesian/utility/v2/ca_response_builder.py
+++ b/bayesian/utility/v2/ca_response_builder.py
@@ -20,7 +20,7 @@ import logging
 from bayesian.utility.db_gateway import GraphAnalyses
 from bayesian.utils import version_info_tuple, convert_version_to_proper_semantic
 
-logger = logging.getLogger(__file__)
+logger = logging.getLogger(__name__)
 
 
 class ComponentAnalyses:

--- a/bayesian/utility/v2/ca_response_builder.py
+++ b/bayesian/utility/v2/ca_response_builder.py
@@ -72,7 +72,7 @@ class ComponentAnalyses:
                 self.ecosystem, self.package, self.version).generate_recommendation(graph_response)
 
         except Exception as e:
-            logger.error(str(e))
+            logger.error('ERROR: %s', str(e))
             return None
 
 

--- a/bayesian/utility/v2/sa_response_builder.py
+++ b/bayesian/utility/v2/sa_response_builder.py
@@ -36,7 +36,7 @@ class StackAnalysesResponseBuilder:
 
     def get_response(self):
         """Aggregate, build and return json response for the given request id."""
-        logger.info('{} SA Get request'.format(self.external_request_id))
+        logger.info('%s SA Get request', self.external_request_id)
 
         # Get db result, stack result and recm data from rdb.
         self._db_result = self.rdb_analyses.get_request_data()

--- a/bayesian/utility/v2/sa_response_builder.py
+++ b/bayesian/utility/v2/sa_response_builder.py
@@ -19,7 +19,7 @@
 import logging
 from bayesian.utils import request_timed_out
 
-logger = logging.getLogger(__file__)
+logger = logging.getLogger(__name__)
 
 
 class StackAnalysesResponseBuilder:
@@ -36,7 +36,7 @@ class StackAnalysesResponseBuilder:
 
     def get_response(self):
         """Aggregate, build and return json response for the given request id."""
-        logger.debug('SA Get request id: {}'.format(self.external_request_id))
+        logger.info('{} SA Get request'.format(self.external_request_id))
 
         # Get db result, stack result and recm data from rdb.
         self._db_result = self.rdb_analyses.get_request_data()

--- a/bayesian/utility/v2/stack_analyses.py
+++ b/bayesian/utility/v2/stack_analyses.py
@@ -106,7 +106,7 @@ class StackAnalyses():
         """Perform backbone request for stack_aggregator and recommender."""
         # Read deps and packages from manifest
         data = self._read_deps_and_packages()
-        logger.info('{} deps and packages data: {}'.format(self._new_request_id, data))
+        logger.info('{r} deps and packages data: {d}'.format(r=self._new_request_id, d=data))
 
         # Set backbone API request body and params.
         request_body = {
@@ -122,8 +122,8 @@ class StackAnalyses():
             'persist': 'true',
             'check_license': 'false'
         }
-        logger.info('{} request_body: {} request_params: {}'.format(
-            self._new_request_id, request_body, request_params))
+        logger.info('{r} request_body: {b} request_params: {p}'.format(
+            r=self._new_request_id, b=request_body, p=request_params))
 
         # Post Backbone stack_aggregator call.
         BackboneServer.post_aggregate_request(request_body, request_params)

--- a/bayesian/utility/v2/stack_analyses.py
+++ b/bayesian/utility/v2/stack_analyses.py
@@ -39,16 +39,16 @@ class StackAnalyses():
 
     def post_request(self):
         """Make stack analyses POST request."""
-        logger.info('SA Post request with ecosys: {} fl name: {} path: {} '
-                    'st: {}'.format(self.params.ecosystem, self.params.manifest.filename,
-                                    self.params.file_path, self.params.show_transitive))
+        logger.info('SA Post request with ecosystem: %s manifest: %s path: %s '
+                    'show_transitive: %s', self.params.ecosystem, self.params.manifest.filename,
+                    self.params.file_path, self.params.show_transitive)
         # Build manifest file info.
         self._manifest_file_info = {
             'filename': self.params.manifest.filename,
             'filepath': self.params.file_path,
             'content': self.params.manifest.read().decode('utf-8')
         }
-        logger.debug('manifest_file_info: {}'.format(self._manifest_file_info))
+        logger.debug('manifest_file_info: %s', self._manifest_file_info)
 
         # Generate unique request id using UUID, also record timestamp in readable form
         self._new_request_id = str(uuid.uuid4().hex)
@@ -66,7 +66,7 @@ class StackAnalyses():
             'submitted_at': date_str,
             'id': self._new_request_id
         }
-        logger.info('{} response: {}'.format(self._new_request_id, data))
+        logger.info('%s response: %s', self._new_request_id, data)
         return data
 
     def _read_deps_and_packages(self):
@@ -93,12 +93,12 @@ class StackAnalyses():
 
             return {'deps': deps, 'packages': packages}
         except (ValueError, json.JSONDecodeError) as e:
-            logger.exception('{} Invalid dependencies encountered. {}'.format(
-                self._new_request_id, e))
+            logger.exception('%s Invalid dependencies encountered. %s',
+                             self._new_request_id, str(e))
             raise SAInvalidInputException('Error while parsing dependencies information') from e
         except Exception as e:
-            logger.exception('{} Unknown exception encountered while parsing deps. {}'.format(
-                self._new_request_id, e))
+            logger.exception('%s Unknown exception encountered while parsing deps. %s',
+                             self._new_request_id, str(e))
             raise SAInvalidInputException('Unknown error while parsing dependencies '
                                           'information') from e
 
@@ -106,7 +106,7 @@ class StackAnalyses():
         """Perform backbone request for stack_aggregator and recommender."""
         # Read deps and packages from manifest
         data = self._read_deps_and_packages()
-        logger.info('{r} deps and packages data: {d}'.format(r=self._new_request_id, d=data))
+        logger.info('%s deps and packages data: %s', self._new_request_id, data)
 
         # Set backbone API request body and params.
         request_body = {
@@ -122,8 +122,8 @@ class StackAnalyses():
             'persist': 'true',
             'check_license': 'false'
         }
-        logger.info('{r} request_body: {b} request_params: {p}'.format(
-            r=self._new_request_id, b=request_body, p=request_params))
+        logger.info('%s request_body: %s request_params: %s',
+                    self._new_request_id, request_body, request_params)
 
         # Post Backbone stack_aggregator call.
         BackboneServer.post_aggregate_request(request_body, request_params)

--- a/bayesian/utility/v2/stack_analyses.py
+++ b/bayesian/utility/v2/stack_analyses.py
@@ -24,7 +24,7 @@ from bayesian.dependency_finder import DependencyFinder
 from bayesian.utility.db_gateway import RdbAnalyses
 from bayesian.utility.v2.backbone_server import BackboneServer
 
-logger = logging.getLogger(__file__)
+logger = logging.getLogger(__name__)
 
 
 class StackAnalyses():
@@ -39,16 +39,16 @@ class StackAnalyses():
 
     def post_request(self):
         """Make stack analyses POST request."""
-        logger.debug('SA Post request with ecosys: {} fl name: {} path: {} '
-                     'st: {}'.format(self.params.ecosystem, self.params.manifest.filename,
-                                     self.params.file_path, self.params.show_transitive))
+        logger.info('SA Post request with ecosys: {} fl name: {} path: {} '
+                    'st: {}'.format(self.params.ecosystem, self.params.manifest.filename,
+                                    self.params.file_path, self.params.show_transitive))
         # Build manifest file info.
         self._manifest_file_info = {
             'filename': self.params.manifest.filename,
             'filepath': self.params.file_path,
             'content': self.params.manifest.read().decode('utf-8')
         }
-        logger.info('manifest_file_info: {}'.format(self._manifest_file_info))
+        logger.debug('manifest_file_info: {}'.format(self._manifest_file_info))
 
         # Generate unique request id using UUID, also record timestamp in readable form
         self._new_request_id = str(uuid.uuid4().hex)
@@ -61,11 +61,13 @@ class StackAnalyses():
         rdbAnalyses = RdbAnalyses(self._new_request_id, date_str,
                                   self._manifest_file_info, deps)
         rdbAnalyses.save_post_request()
-        return {
+        data = {
             'status': 'success',
             'submitted_at': date_str,
             'id': self._new_request_id
         }
+        logger.info('{} response: {}'.format(self._new_request_id, data))
+        return data
 
     def _read_deps_and_packages(self):
         """Read dependencies and packages information from manifest file content."""
@@ -77,7 +79,6 @@ class StackAnalyses():
             d = DependencyFinder()
             deps = d.scan_and_find_dependencies(self.params.ecosystem, [self._manifest_file_info],
                                                 json.dumps(self.params.show_transitive))
-            logger.info('deps: {}'.format(deps))
 
             # Build package details.
             resolved = deps.get('result', [{}])[0].get('details', [{}])[0].get('_resolved', None)
@@ -90,13 +91,14 @@ class StackAnalyses():
                                          for pkg in p.get('deps', [])]
                     })
 
-            logger.debug('result: {}'.format({'deps': deps, 'packages': packages}))
             return {'deps': deps, 'packages': packages}
         except (ValueError, json.JSONDecodeError) as e:
-            logger.exception('Invalid dependencies encountered. {}'.format(e))
+            logger.exception('{} Invalid dependencies encountered. {}'.format(
+                self._new_request_id, e))
             raise SAInvalidInputException('Error while parsing dependencies information') from e
         except Exception as e:
-            logger.exception('Unknown exception encountered while parsing deps. {}'.format(e))
+            logger.exception('{} Unknown exception encountered while parsing deps. {}'.format(
+                self._new_request_id, e))
             raise SAInvalidInputException('Unknown error while parsing dependencies '
                                           'information') from e
 
@@ -104,7 +106,7 @@ class StackAnalyses():
         """Perform backbone request for stack_aggregator and recommender."""
         # Read deps and packages from manifest
         data = self._read_deps_and_packages()
-        logger.info('deps data: {}'.format(data))
+        logger.info('{} deps and packages data: {}'.format(self._new_request_id, data))
 
         # Set backbone API request body and params.
         request_body = {
@@ -120,7 +122,8 @@ class StackAnalyses():
             'persist': 'true',
             'check_license': 'false'
         }
-        logger.info('request_body: {} request_params: {}'.format(request_body, request_params))
+        logger.info('{} request_body: {} request_params: {}'.format(
+            self._new_request_id, request_body, request_params))
 
         # Post Backbone stack_aggregator call.
         BackboneServer.post_aggregate_request(request_body, request_params)

--- a/bayesian/utils.py
+++ b/bayesian/utils.py
@@ -68,7 +68,7 @@ def server_run_flow(flow_name, flow_args):
     :param flow_args: arguments for the flow
     :return: dispatcher ID handling flow
     """
-    logger.debug('Running flow {}'.format(flow_name))
+    logger.debug('Running flow %s', flow_name)
     start = datetime.datetime.now()
 
     init_celery(result_backend=False)
@@ -76,8 +76,7 @@ def server_run_flow(flow_name, flow_args):
 
     # compute the elapsed time
     elapsed_seconds = (datetime.datetime.now() - start).total_seconds()
-    logger.debug("It took {t:.2f} seconds to start {f} flow.".format(
-        t=elapsed_seconds, f=flow_name))
+    logger.debug('It took %f seconds to start %s flow.', elapsed_seconds, flow_name)
     return dispacher_id
 
 
@@ -400,8 +399,7 @@ g.V().has('pecosystem', ecosystem).has('pname', name).has('version', version).as
     finally:
         elapsed_seconds = (datetime.datetime.now() - start).total_seconds()
         epv = "{e}/{p}/{v}".format(e=ecosystem, p=package, v=version)
-        logger.debug("Gremlin request {p} took {t:.2f} seconds.".format(p=epv,
-                                                                        t=elapsed_seconds))
+        logger.debug('Gremlin request %s took %f seconds.', epv, elapsed_seconds)
 
     resp = generate_recommendation(clubbed_data, package, version)
     return resp
@@ -583,8 +581,8 @@ def get_next_component_from_graph(ecosystem, user_id, company):
         return None
     finally:
         elapsed_seconds = (datetime.datetime.now() - start).total_seconds()
-        logger.debug("Gremlin request for next component for ecosystem {e} took {t:.2f} "
-                     "seconds.".format(e=ecosystem, t=elapsed_seconds))
+        logger.debug('Gremlin request for next component for ecosystem %s took %f '
+                     'seconds.', ecosystem, elapsed_seconds)
 
     resp = graph_req.json()
 
@@ -623,8 +621,8 @@ def set_tags_to_component(ecosystem, package, tags, user_id, company):
         return False, ' '.join([type(e), ':', str(e)])
     finally:
         elapsed_seconds = (datetime.datetime.now() - start).total_seconds()
-        logger.debug(("Gremlin request for setting tags to component for ecosystem"
-                      " {e} took {t:.2f} seconds.".format(e=ecosystem, t=elapsed_seconds)))
+        logger.debug('Gremlin request for setting tags to component for ecosystem '
+                     '%s took %f seconds.', ecosystem, elapsed_seconds)
     return True, None
 
 
@@ -663,10 +661,8 @@ def retrieve_worker_results(rdb, external_request_id):
         raise
 
     # compute elapsed time
-    elapsed_seconds = (datetime.datetime.now() - start).total_seconds()
-    msg = "{r} took {t:.2f} seconds to retrieve all worker results.".format(
-        r=external_request_id, t=elapsed_seconds)
-    logger.debug(msg)
+    logger.debug('%s took %f seconds to retrieve all worker results.',
+                 external_request_id, (datetime.datetime.now() - start).total_seconds())
 
     return results
 
@@ -687,10 +683,9 @@ def retrieve_worker_result(rdb, external_request_id, worker):
     result_dict = result.to_dict()
 
     # compute elapsed time
-    elapsed_seconds = (datetime.datetime.now() - start).total_seconds()
-    msg = "{r} took {t:.2f} seconds to retrieve {w} worker results.".format(
-        r=external_request_id, t=elapsed_seconds, w=worker)
-    logger.debug(msg)
+    logger.debug('%s took %f seconds to retrieve %s worker results.',
+                 external_request_id, (datetime.datetime.now() - start).total_seconds(),
+                 worker)
 
     return result_dict
 
@@ -864,8 +859,7 @@ class RecommendationReason:
                 This should track any future occurence of this[1] error:
                 Error:https://github.com/openshiftio/openshift.io/issues/2167
                 """
-                logger.error(
-                    "Stack Count for {} when confidence=None is {}".format(name, stack_count))
+                logger.error('Stack Count for %s when confidence=None is %d', name, stack_count)
 
             # 0% confidence is as good as not showing it on the UI.
             if stack_confidence == 0:
@@ -918,9 +912,8 @@ def convert_version_to_proper_semantic(version, package_name=None):
         version = version.replace('-', '+', 3)
         conv_version = sv.Version.coerce(version)
     except ValueError:
-        logger.info(
-            "Unexpected ValueError for the package {} due to version {}"
-            .format(package_name, version))
+        logger.error('Unexpected ValueError for the package %s due to version %s',
+                     package_name, version)
         pass
     finally:
         return conv_version
@@ -958,10 +951,8 @@ def select_latest_version(latest='', libio='', package_name=None):
         """In case of failure let's not show any latest version at all.
         Also, no generation of stack trace,
         as we are only intersted in the package that is causing the error."""
-        logger.info(
-            "Unexpected ValueError while selecting latest version for package {}. Debug:{}"
-            .format(package_name,
-                    {'latest': latest, 'libio': libio}))
+        logger.error('Unexpected ValueError while selecting latest version for package %s. '
+                     'Debug:%s', package_name, {'latest': latest, 'libio': libio})
         return_version = ''
     finally:
         return return_version
@@ -990,7 +981,7 @@ def fetch_file_from_github(url, filename, branch='master'):
     except ValueError:
         logger.error('Error fetching file from given url')
     except Exception as e:
-        logger.error('ERROR: {}'.format(str(e)))
+        logger.error('ERROR: %s', str(e))
 
 
 def fetch_file_from_github_release(url, filename, token, ref=None):
@@ -1021,8 +1012,8 @@ def fetch_file_from_github_release(url, filename, token, ref=None):
         except GithubException as e:
             HTTPError(404, 'Github repository does not exist {}'.format(str(e)))
         except Exception as e:
-            logger.error('An Exception occured while fetching file github release {}'
-                         .format(str(e)))
+            logger.error('An Exception occured while fetching file github release %s',
+                         str(e))
     else:
         logger.error("Github access token is not provided")
 

--- a/bayesian/utils.py
+++ b/bayesian/utils.py
@@ -397,9 +397,9 @@ g.V().has('pecosystem', ecosystem).has('pname', name).has('version', version).as
         logger.debug(' '.join([type(e), ':', str(e)]))
         return None
     finally:
-        elapsed_seconds = (datetime.datetime.now() - start).total_seconds()
         epv = "{e}/{p}/{v}".format(e=ecosystem, p=package, v=version)
-        logger.debug('Gremlin request %s took %f seconds.', epv, elapsed_seconds)
+        logger.debug('Gremlin request %s took %f seconds.',
+                     epv, (datetime.datetime.now() - start).total_seconds())
 
     resp = generate_recommendation(clubbed_data, package, version)
     return resp
@@ -580,9 +580,8 @@ def get_next_component_from_graph(ecosystem, user_id, company):
         logger.debug(' '.join([type(e), ':', str(e)]))
         return None
     finally:
-        elapsed_seconds = (datetime.datetime.now() - start).total_seconds()
-        logger.debug('Gremlin request for next component for ecosystem %s took %f '
-                     'seconds.', ecosystem, elapsed_seconds)
+        logger.debug('Gremlin request for next component for ecosystem %s took %f seconds.',
+                     ecosystem, (datetime.datetime.now() - start).total_seconds())
 
     resp = graph_req.json()
 
@@ -620,9 +619,8 @@ def set_tags_to_component(ecosystem, package, tags, user_id, company):
     except Exception as e:
         return False, ' '.join([type(e), ':', str(e)])
     finally:
-        elapsed_seconds = (datetime.datetime.now() - start).total_seconds()
-        logger.debug('Gremlin request for setting tags to component for ecosystem '
-                     '%s took %f seconds.', ecosystem, elapsed_seconds)
+        logger.debug('Gremlin request for setting tags to component for ecosystem %s took %f '
+                     'seconds.', ecosystem, (datetime.datetime.now() - start).total_seconds())
     return True, None
 
 
@@ -1015,7 +1013,7 @@ def fetch_file_from_github_release(url, filename, token, ref=None):
             logger.error('An Exception occured while fetching file github release %s',
                          str(e))
     else:
-        logger.error("Github access token is not provided")
+        logger.error('Github access token is not provided')
 
 
 def is_valid(param):

--- a/bayesian/utils.py
+++ b/bayesian/utils.py
@@ -74,9 +74,8 @@ def server_run_flow(flow_name, flow_args):
     init_celery(result_backend=False)
     dispacher_id = run_flow(flow_name, flow_args)
 
-    # compute the elapsed time
-    elapsed_seconds = (datetime.datetime.now() - start).total_seconds()
-    logger.debug('It took %f seconds to start %s flow.', elapsed_seconds, flow_name)
+    logger.debug('It took %f seconds to start %s flow.',
+                 (datetime.datetime.now() - start).total_seconds(), flow_name)
     return dispacher_id
 
 

--- a/hack/coreapi-server.sh
+++ b/hack/coreapi-server.sh
@@ -4,7 +4,7 @@ set -e
 
 # NOTE: the --python-eggs /home/coreapi is there before I figure out a proper solution
 #   https://github.com/GrahamDumpleton/mod_wsgi/issues/125 or upstream fixes it
-# TIMEOUT params --request-timeout socket-timeout should be added for requests taking longer than expected 
+# TIMEOUT params --request-timeout socket-timeout should be added for requests taking longer than expected
 exec mod_wsgi-express start-server \
                       --entry-point bayesian \
                       --application-type module \
@@ -17,6 +17,7 @@ exec mod_wsgi-express start-server \
                       ${!F8A_DEBUG:---reload-on-changes} \
                       --access-log \
                       --access-log-format "%h %l %u %t \"%r\" %>s %b %{Referer}i \"%{User-agent}i\"" \
+                      --error-log-format "%M" \
                       --log-to-terminal \
                       --python-eggs /home/coreapi \
                       --include-file /etc/httpd/conf.d/coreapi-httpd.conf \

--- a/hack/coreapi-server.sh
+++ b/hack/coreapi-server.sh
@@ -3,7 +3,7 @@
 set -e
 
 # NOTE: the --python-eggs /home/coreapi is there before I figure out a proper solution
-#       https://github.com/GrahamDumpleton/mod_wsgi/issues/125 or upstream fixes it
+#   https://github.com/GrahamDumpleton/mod_wsgi/issues/125 or upstream fixes it
 # TIMEOUT params --request-timeout socket-timeout should be added for requests taking longer than expected
 exec mod_wsgi-express start-server \
                       --entry-point bayesian \

--- a/hack/coreapi-server.sh
+++ b/hack/coreapi-server.sh
@@ -3,7 +3,7 @@
 set -e
 
 # NOTE: the --python-eggs /home/coreapi is there before I figure out a proper solution
-#   https://github.com/GrahamDumpleton/mod_wsgi/issues/125 or upstream fixes it
+#       https://github.com/GrahamDumpleton/mod_wsgi/issues/125 or upstream fixes it
 # TIMEOUT params --request-timeout socket-timeout should be added for requests taking longer than expected
 exec mod_wsgi-express start-server \
                       --entry-point bayesian \

--- a/hack/coreapi-server.sh
+++ b/hack/coreapi-server.sh
@@ -16,7 +16,7 @@ exec mod_wsgi-express start-server \
                       --threads 1 \
                       ${!F8A_DEBUG:---reload-on-changes} \
                       --access-log \
-                      --access-log-format "%h %l %u %t \"%r\" %>s %b %{Referer}i \"%{User-agent}i\"" \
+                      --access-log-format "[%{%Y-%m-%d %H:%M:%S,}t%{msec_frac}t] INFO Access from %h %r %>s %b %{Referer}i \"%{User-agent}i\"" \
                       --error-log-format "%M" \
                       --log-to-terminal \
                       --python-eggs /home/coreapi \

--- a/tests/api/test_api_v2.py
+++ b/tests/api/test_api_v2.py
@@ -276,12 +276,26 @@ class TestStackAnalysesPostApi(unittest.TestCase):
                                     content_type='multipart/form-data')
         self.assertEqual(response.status_code, 400)
 
-    def test_sa_post_invalid_manifest_file_content(self):
+    def test_sa_post_invalid_ecosystem_and_manifest(self):
         """Post request with invalid manifest file content. Expecting http error 400."""
         data = {
             'manifest': (io.StringIO(str(Path(__file__).parent /
                                          '../data/manifests/400/npmlist.json')).read(),
                          'npmlist.json'),
+            'file_path': '/tmp/bin',
+            'ecosystem': 'pypi'
+        }
+        response = self.client.post(api_route_for('/stack-analyses'),
+                                    data=data,
+                                    content_type='multipart/form-data')
+        self.assertEqual(response.status_code, 400)
+
+    def test_sa_post_invalid_manifest_file_content(self):
+        """Post request with invalid manifest file content. Expecting http error 400."""
+        data = {
+            'manifest': (io.StringIO(str(Path(__file__).parent /
+                                         '../data/manifests/400/npmlist.json')).read(),
+                         'pylist.json'),
             'file_path': '/tmp/bin',
             'ecosystem': 'pypi'
         }

--- a/tests/test_license_extractor.py
+++ b/tests/test_license_extractor.py
@@ -22,8 +22,7 @@ def current_app_logger(_str):
     pass
 
 
-@patch('bayesian.license_extractor.current_app', side_effect=current_app_logger)
-def test_get_license_synonyms(_mocked_object):
+def test_get_license_synonyms():
     """Test the function get_license_synonyms()."""
     # make sure the LRU cache is clear
     get_license_synonyms.cache.clear()
@@ -53,9 +52,8 @@ def mocked_requests_get(url):
     return _response(404, "Not Found!")
 
 
-@patch('bayesian.license_extractor.current_app', side_effect=current_app_logger)
 @patch("bayesian.license_extractor.get", side_effect=mocked_requests_get)
-def test_get_license_synonyms_wrong_response(mocked_get, _mocked_function):
+def test_get_license_synonyms_wrong_response(mocked_get):
     """Test the function get_license_synonyms()."""
     # make sure the LRU cache is clear
     get_license_synonyms.cache.clear()
@@ -71,8 +69,7 @@ def _check_extracted_license(result, expected_license):
     assert result[1] == expected_license
 
 
-@patch('bayesian.license_extractor.current_app', side_effect=current_app_logger)
-def test_extract_licenses(_mocked_object):
+def test_extract_licenses():
     """Test the function extract_licenses()."""
     # TODO: reduce cyclomatic complexity
     # make sure the LRU cache is clear
@@ -110,8 +107,7 @@ def test_extract_licenses_no_synonyms(mocked_function):
     assert mocked_function.called
 
 
-@patch('bayesian.license_extractor.current_app', side_effect=current_app_logger)
-def test_extract_licenses_wrong_file(_mocked_function):
+def test_extract_licenses_wrong_file():
     """Test the function extract_licenses()."""
     # make sure the LRU cache is clear
     get_license_synonyms.cache.clear()

--- a/tests/utility/v2/test_backbone_server.py
+++ b/tests/utility/v2/test_backbone_server.py
@@ -38,7 +38,8 @@ class TestBackboneServer(unittest.TestCase):
            return_value={})
     def test_agg_request_success(self, _post):
         """Test aggregate post request with correct data."""
-        self.assertEqual(BackboneServer.post_aggregate_request({}, {}), None)
+        self.assertEqual(BackboneServer.post_aggregate_request(
+            {'external_request_id': 'test_request_id'}, {}), None)
 
     @patch('bayesian.utility.v2.backbone_server.BackboneServer.session.post',
            side_effect=Exception('Mock exception'))
@@ -53,4 +54,5 @@ class TestBackboneServer(unittest.TestCase):
            return_value={})
     def test_recm_request_success(self, _post):
         """Test recommendation post request with correct data."""
-        self.assertEqual(BackboneServer.post_recommendations_request({}, {}), None)
+        self.assertEqual(BackboneServer.post_recommendations_request(
+            {'external_request_id': 'test_request_id'}, {}), None)

--- a/tests/utility/v2/test_stack_analyses.py
+++ b/tests/utility/v2/test_stack_analyses.py
@@ -43,6 +43,20 @@ class TestStackAnalyses(unittest.TestCase):
                 sa.post_request()
             self.assertIs(exception.type, SAInvalidInputException)
 
+    @patch('bayesian.utility.v2.stack_analyses.DependencyFinder.scan_and_find_dependencies',
+           side_effect=Exception('Mock error'))
+    def test_sa_invalid_manifest_file_unknown_error(self, _mock_depfinder):
+        """Check if 400 is raise upon invalid manifest file."""
+        with open(str(Path(__file__).parent.parent.parent) +
+                  '/data/manifests/400/npmlist.json', 'rb') as fp:
+            fs = FileStorage(stream=fp, filename='npmlist.json')
+            sa_post_request = StackAnalysesPostRequest(manifest=fs, file_path='/tmp/bin',
+                                                       ecosystem='npm', show_transitive=True)
+            sa = StackAnalyses(sa_post_request)
+            with pytest.raises(Exception) as exception:
+                sa.post_request()
+            self.assertIs(exception.type, SAInvalidInputException)
+
     def test_sa_mismatch_manifest_file_and_ecosystem(self):
         """Check if 400 is raise upon mismatch between manifest file content and ecosystem type."""
         with open(str(Path(__file__).parent.parent.parent) +


### PR DESCRIPTION
Unifying logging in API server, adding profiling logs to measure timing information.

Jira Issue:: https://issues.redhat.com/browse/APPAI-1387

Logs for one post, inpogress and get request.

```
[2020-07-20 08:03:01,996] DEBUG in /usr/local/lib/python3.6/site-packages/bayesian/api/api_v2.py:243: [POST] /stack-analyses accessed
[2020-07-20 08:03:01,999] INFO in /usr/local/lib/python3.6/site-packages/bayesian/utility/v2/stack_analyses.py:44: SA Post request with ecosystem: Ecosystem.maven manifest: dependencies.txt path: /tmp/bin show_transitive: True
[2020-07-20 08:03:01,999] DEBUG in /usr/local/lib/python3.6/site-packages/bayesian/utility/v2/stack_analyses.py:51: manifest_file_info: {'filename': 'dependencies.txt', 'filepath': '/tmp/bin', 'content': 'digraph "com.redhat.bayessian.test:test-app-logging:jar:1.0" { \\n\\t"com.redhat.bayessian.test:test-app-logging:jar:1.0" -> "commons-logging:commons-logging:jar:1.2:compile" ; \\n } '}
[2020-07-20 08:03:01,999] INFO in /usr/local/lib/python3.6/site-packages/bayesian/utility/v2/stack_analyses.py:109: dd3f224999104fcc813892baee2aa877 deps and packages data: {'deps': {'result': [{'details': [{'ecosystem': <Ecosystem.maven: 'maven'>, 'manifest_file_path': '/tmp/bin', 'manifest_file': 'dependencies.txt', '_resolved': [{'package': 'commons-logging:commons-logging', 'version': '1.2', 'deps': []}]}]}]}, 'packages': [{'name': 'commons-logging:commons-logging', 'version': '1.2', 'dependencies': []}]}
[2020-07-20 08:03:01,999] INFO in /usr/local/lib/python3.6/site-packages/bayesian/utility/v2/stack_analyses.py:126: dd3f224999104fcc813892baee2aa877 request_body: {'registration_status': 'freetier', 'external_request_id': 'dd3f224999104fcc813892baee2aa877', 'ecosystem': <Ecosystem.maven: 'maven'>, 'packages': [{'name': 'commons-logging:commons-logging', 'version': '1.2', 'dependencies': []}], 'manifest_name': 'dependencies.txt', 'manifest_file_path': '/tmp/bin', 'show_transitive': True} request_params: {'persist': 'true', 'check_license': 'false'}
[2020-07-20 08:03:01,999] DEBUG in /usr/local/lib/python3.6/site-packages/bayesian/utility/v2/backbone_server.py:45: Aggregator request for backbone host: http://f8a-server-backbone:5000  body: {'registration_status': 'freetier', 'external_request_id': 'dd3f224999104fcc813892baee2aa877', 'ecosystem': <Ecosystem.maven: 'maven'>, 'packages': [{'name': 'commons-logging:commons-logging', 'version': '1.2', 'dependencies': []}], 'manifest_name': 'dependencies.txt', 'manifest_file_path': '/tmp/bin', 'show_transitive': True} params: {'persist': 'true', 'check_license': 'false'}
[2020-07-20 08:03:02,001] DEBUG in /usr/local/lib/python3.6/site-packages/bayesian/utility/v2/backbone_server.py:54: dd3f224999104fcc813892baee2aa877 took 0.001384 seconds for /api/v2/stack_aggregator
[2020-07-20 08:03:02,001] DEBUG in /usr/local/lib/python3.6/site-packages/bayesian/utility/v2/backbone_server.py:64: Recommendation request for backbone host: http://f8a-server-backbone:5000  body: {'registration_status': 'freetier', 'external_request_id': 'dd3f224999104fcc813892baee2aa877', 'ecosystem': <Ecosystem.maven: 'maven'>, 'packages': [{'name': 'commons-logging:commons-logging', 'version': '1.2', 'dependencies': []}], 'manifest_name': 'dependencies.txt', 'manifest_file_path': '/tmp/bin', 'show_transitive': True} params: {'persist': 'true', 'check_license': 'false'}
[2020-07-20 08:03:02,002] DEBUG in /usr/local/lib/python3.6/site-packages/bayesian/utility/v2/backbone_server.py:73: dd3f224999104fcc813892baee2aa877 took 0.000290 seconds for /api/v2/recommender
[2020-07-20 08:03:02,012] DEBUG in /usr/local/lib/python3.6/site-packages/urllib3/connectionpool.py:205: Starting new HTTP connection (1): f8a-server-backbone:5000
[2020-07-20 08:03:02,015] DEBUG in /usr/local/lib/python3.6/site-packages/urllib3/connectionpool.py:205: Starting new HTTP connection (2): f8a-server-backbone:5000
/usr/local/lib64/python3.6/site-packages/psycopg2/__init__.py:144: UserWarning: The psycopg2 wheel package will be renamed from release 2.8; in order to keep installing from binary please use "pip install psycopg2-binary" instead. For details see: <http://initd.org/psycopg/docs/install.html#binary-install-from-pypi> .
  """)
[2020-07-20 08:03:02,168] INFO in /usr/local/lib/python3.6/site-packages/bayesian/utility/db_gateway.py:132: dd3f224999104fcc813892baee2aa877 took 0.165812 seconds to save data
[2020-07-20 08:03:02,168] INFO in /usr/local/lib/python3.6/site-packages/bayesian/utility/v2/stack_analyses.py:69: dd3f224999104fcc813892baee2aa877 response: {'status': 'success', 'submitted_at': '2020-07-20 08:03:01.999435', 'id': 'dd3f224999104fcc813892baee2aa877'}
[2020-07-20 08:03:02,168] INFO in /usr/local/lib/python3.6/site-packages/bayesian/api/api_v2.py:268: dd3f224999104fcc813892baee2aa877 took 0.169883 seconds for [POST] stack-analyses
[2020-07-20 08:03:01,772] INFO Access from 10.128.0.1 POST /api/v2/stack-analyses?user_key=not-set HTTP/1.1 200 120 - "PostmanRuntime/7.26.1"
[2020-07-20 08:03:02,641] DEBUG in /usr/local/lib/python3.6/site-packages/urllib3/connectionpool.py:393: http://f8a-server-backbone:5000  "POST /api/v2/recommender?persist=true&check_license=false HTTP/1.1" 200 5296
[2020-07-20 08:03:03,293] DEBUG in /usr/local/lib/python3.6/site-packages/urllib3/connectionpool.py:393: http://f8a-server-backbone:5000  "POST /api/v2/stack_aggregator?persist=true&check_license=false HTTP/1.1" 200 3553
[2020-07-20 08:03:22,788] INFO in /usr/local/lib/python3.6/site-packages/fabric8a_auth/auth.py:102: Request has been successfully authenticated
[2020-07-20 08:03:22,788] DEBUG in /usr/local/lib/python3.6/site-packages/bayesian/api/api_v2.py:211: [GET] /stack-analyses/dd3f224999104fcc813892baee2aa877
[2020-07-20 08:03:22,790] INFO in /usr/local/lib/python3.6/site-packages/bayesian/utility/v2/sa_response_builder.py:39: dd3f224999104fcc813892baee2aa877 SA Get request
/usr/local/lib64/python3.6/site-packages/psycopg2/__init__.py:144: UserWarning: The psycopg2 wheel package will be renamed from release 2.8; in order to keep installing from binary please use "pip install psycopg2-binary" instead. For details see: <http://initd.org/psycopg/docs/install.html#binary-install-from-pypi> .
  """)
[2020-07-20 08:03:23,034] INFO in /usr/local/lib/python3.6/site-packages/bayesian/utility/db_gateway.py:95: dd3f224999104fcc813892baee2aa877 took 0.243630 seconds to fetch data
[2020-07-20 08:03:23,045] DEBUG in /usr/local/lib/python3.6/site-packages/bayesian/utils.py:688: dd3f224999104fcc813892baee2aa877 took 0.011089 seconds to retrieve stack_aggregator_v2 worker results.
[2020-07-20 08:03:23,055] DEBUG in /usr/local/lib/python3.6/site-packages/bayesian/utils.py:688: dd3f224999104fcc813892baee2aa877 took 0.009575 seconds to retrieve recommendation_v2 worker results.
[2020-07-20 08:03:23,055] INFO in /usr/local/lib/python3.6/site-packages/bayesian/api/api_v2.py:221: dd3f224999104fcc813892baee2aa877 took 0.266905 seconds for [GET] stack-analyses
[2020-07-20 08:03:22,783] INFO Access from 10.128.0.1 GET /api/v2/stack-analyses/dd3f224999104fcc813892baee2aa877?user_key=not-set HTTP/1.1 200 8367 - "PostmanRuntime/7.26.1"
```