### PR TITLE
fix: update message for registered user response

### DIFF
--- a/api_specs/v2/component_analyses.yaml
+++ b/api_specs/v2/component_analyses.yaml
@@ -263,11 +263,11 @@ components:
                 - "1.1.3"
                 - "1.2.4"
           recommended_versions : "2"
-          message: "3 vulnerabilities within this dependency, 0 exploitable vulnerabilities"
+          message: "3 vulnerabilities within this dependency, 1 exploitable vulnerabilities"
           highest_severity: "high"
           known_security_vulnerability_count: 2
           security_advisory_count: 1
-          exploitable_vulnerabilities_count: 0
+          exploitable_vulnerabilities_count: 1
           vendor_package_link: "https://snyk.io/vuln/maven:org.zeroturnaround%3Azt-zip"
         - package: "mango"
           version: "2.1"
@@ -304,11 +304,11 @@ components:
                 - "1.1.3"
                 - "1.2.4"
           recommended_versions : "2"
-          message: "3 vulnerabilities within this dependency, 0 exploitable vulnerabilities"
+          message: "3 vulnerabilities within this dependency, 1 exploitable vulnerabilities"
           highest_severity: "high"
           known_security_vulnerability_count: 2
           security_advisory_count: 1
-          exploitable_vulnerabilities_count: 0
+          exploitable_vulnerabilities_count: 1
           vendor_package_link: "https://snyk.io/vuln/maven:org.zeroturnaround%3Azt-zip"
     no-vul-batch:
       value:
@@ -330,11 +330,11 @@ components:
                 cvss: "1.3"
                 is_private: false
           recommended_version : "2"
-          message: "3 vulnerabilities within this dependency, 0 exploitable vulnerabilities"
+          message: "3 vulnerabilities within this dependency, 1 exploitable vulnerabilities"
           severity: "high"
           public_vulnerabilities_count: 2
           private_vulnerabilities_count: 1
-          exploitable_vulnerabilities_count: 0
+          exploitable_vulnerabilities_count: 1
           vendor_package_link: "https://snyk.io/vuln/maven:org.zeroturnaround%3Azt-zip"
 
     free-user:
@@ -447,7 +447,7 @@ components:
             $ref: '#/components/schemas/VulnerabilityDetailsBatch'
         message:
           type: string
-          example: "3 vulnerabilities within this dependency, 0 exploitable vulnerabilities"
+          example: "3 vulnerabilities within this dependency, 1 exploitable vulnerabilities"
         highest_severity:
           type: string
           example: "high"
@@ -459,7 +459,7 @@ components:
           example: 0
         exploitable_vulnerabilities_count:
           type: integer
-          example: 0
+          example: 1
         vendor_package_link:
           type: string
           example : "https://snyk.io/vuln/maven:org.webjars%3Ajquery-form"
@@ -486,7 +486,7 @@ components:
             $ref: '#/components/schemas/VulnerabilityDetailsBatch'
         message:
           type: string
-          example: "3 vulnerabilities within this dependency, 0 exploitable vulnerabilities"
+          example: "2 vulnerabilities within this dependency"
         highest_severity:
           type: string
           example: "high"
@@ -637,7 +637,7 @@ components:
               $ref: '#/components/schemas/VulnerabilityDetails'
             message:
               type: string
-              example: "3 vulnerabilities within this dependency, 0 exploitable vulnerabilities"
+              example: "3 vulnerabilities within this dependency, 1 exploitable vulnerabilities"
             severity:
               type: string
               example: "high"
@@ -649,7 +649,7 @@ components:
               example: 0
             exploitable_vulnerabilities_count:
               type: integer
-              example: 0
+              example: 1
             vendor_package_link:
               type: string
               example : "https://snyk.io/vuln/maven:org.webjars%3Ajquery-form"
@@ -674,7 +674,7 @@ components:
               $ref: '#/components/schemas/VulnerabilityDetails'
             message:
               type: string
-              example: "3 vulnerabilities within this dependency, 0 exploitable vulnerabilities"
+              example: "2 vulnerabilities within this dependency"
             highest_severity:
               type: string
               example: "high"

--- a/bayesian/utility/v2/ca_response_builder.py
+++ b/bayesian/utility/v2/ca_response_builder.py
@@ -472,23 +472,33 @@ class CABatchResponseBuilder(ComponentResponseBase):
         if self.public_vul and self.pvt_vul:
             # Add Private Vulnerability and Public Vul Info only
             message += f"{self.public_vul} known security vulnerability "
-            message += f"and {self.pvt_vul} security advisory "
-            message += f"with {exploitable_vuls} exploitable vulnerabilities. "
+            message += f"and {self.pvt_vul} security advisory with "
+            message += self.append_with_exploit_details(exploitable_vuls)
+            message += f"{self.severity[0]} severity. "
             message += self.get_recommendation()
             return message
 
         if self.public_vul:
             # Add Public Vulnerability Info only
-            message += f"{self.public_vul} known security vulnerability"
-            message += f" with {exploitable_vuls} exploitable vulnerabilities. "
+            message += f"{self.public_vul} known security vulnerability with "
+            message += self.append_with_exploit_details(exploitable_vuls)
+            message += f"{self.severity[0]} severity. "
             message += self.get_recommendation()
             return message
 
         if self.pvt_vul:
             # Add Private Vulnerability Info only
-            message += f"{self.pvt_vul} security advisory"
-            message += f" with {exploitable_vuls} exploitable vulnerabilities. "
+            message += f"{self.pvt_vul} security advisory with "
+            message += self.append_with_exploit_details(exploitable_vuls)
+            message += f"{self.severity[0]} severity. "
+            message += self.get_recommendation()
         return message
+
+    def append_with_exploit_details(self, exploitable_vuls) -> str:
+        """Append exploit details to message."""
+        if exploitable_vuls:
+            return f"{exploitable_vuls} exploitable vulnerability and "
+        return ""
 
     def generate_response(self) -> Dict:
         """Build a JSON Response from all calculated values.

--- a/tests/utility/v2/test_ca_response_builder.py
+++ b/tests/utility/v2/test_ca_response_builder.py
@@ -184,10 +184,11 @@ class ComponentAnalysisResponseBuilderTest(unittest.TestCase):
         obj.pvt_vul = 1
         obj.package = "django"
         obj.version = "1.1"
+        obj.severity = ['high']
         msg = obj.get_premium_message(1)
         ideal_msg = "django - 1.1 has 1 known security vulnerability " \
                     "and 1 security advisory with 1 exploitable " \
-                    "vulnerabilities. No recommended version."
+                    "vulnerability and high severity. No recommended version."
         self.assertEqual(msg, ideal_msg)
 
     def test_get_premium_message_with_pvt_vul(self):
@@ -197,8 +198,10 @@ class ComponentAnalysisResponseBuilderTest(unittest.TestCase):
         obj.pvt_vul = 1
         obj.package = "django"
         obj.version = "1.1"
+        obj.severity = ['high']
         msg = obj.get_premium_message(1)
-        ideal_msg = "django - 1.1 has 1 security advisory with 1 exploitable vulnerabilities. "
+        ideal_msg = "django - 1.1 has 1 security advisory with 1 exploitable " \
+                    "vulnerability and high severity. No recommended version."
         self.assertEqual(msg, ideal_msg)
 
     def test_get_premium_message_with_public_vul(self):
@@ -208,9 +211,23 @@ class ComponentAnalysisResponseBuilderTest(unittest.TestCase):
         obj.pvt_vul = 0
         obj.package = "django"
         obj.version = "1.1"
+        obj.severity = ['high']
         msg = obj.get_premium_message(1)
         ideal_msg = "django - 1.1 has 1 known security vulnerability with " \
-                    "1 exploitable vulnerabilities. No recommended version."
+                    "1 exploitable vulnerability and high severity. No recommended version."
+        self.assertEqual(msg, ideal_msg)
+
+    def test_get_premium_message_with_0_exploit_vul(self):
+        """Test Get Premium Message With Public Vulnerabilities."""
+        obj = CABatchResponseBuilder(self.eco)
+        obj.public_vul = 1
+        obj.pvt_vul = 1
+        obj.package = "django"
+        obj.version = "1.1"
+        obj.severity = ['high']
+        msg = obj.get_premium_message(0)
+        ideal_msg = "django - 1.1 has 1 known security vulnerability " \
+                    "and 1 security advisory with high severity. No recommended version."
         self.assertEqual(msg, ideal_msg)
 
     def test_get_message_with_pvt_vul_equal_len(self):


### PR DESCRIPTION
Update message for registered user response:

- Do not show exploit details if exploitable vulnerability count is 0.

- Show highest severity of the vulnerability.

- Also show recommended version for only security advisories. (for registered user only)

https://issues.redhat.com/browse/APPAI-1479 
https://issues.redhat.com/browse/APPAI-1512 