### PR TITLE
fix: double pkg output issue resolved

### DIFF
--- a/bayesian/utility/v2/component_analyses.py
+++ b/bayesian/utility/v2/component_analyses.py
@@ -124,64 +124,48 @@ def ca_validate_input(input_json: Dict, ecosystem: str) -> Tuple[List[Dict], Lis
 def get_known_unknown_pkgs(
         ecosystem: str, graph_response: Dict,
         normalised_input_pkgs: List) -> Tuple[List[Dict], Set[Package]]:
-    """Analyse Known and Unknown Packages."""
+    """Analyse Known and Unknown Packages.
+
+    :param ecosystem: Ecosystem
+    :param graph_response: Graph Response
+    :param normalised_input_pkgs: Normalised Input Packages
+    :return: Stack Recommendations, Unknown Pkgs
+    """
+    normalised_input_pkg_map = None  # Mapping is required only for Golang.
     if ecosystem == 'golang':
-        stack_recommendation, db_known_packages = get_stack_recommendation_for_golang(
-            ecosystem, graph_response, normalised_input_pkgs)
-    else:
-        stack_recommendation, db_known_packages = get_stack_recommendation(
-            ecosystem, graph_response, normalised_input_pkgs)
+        normalised_input_pkg_map = {input_pkg.name: input_pkg.given_version
+                                    for input_pkg in normalised_input_pkgs}
+
+    stack_recommendation = []
+    db_known_packages = set()
+    for package in graph_response.get('result', {}).get('data'):
+        pkg_name = package.get('package').get('name', [''])[0]
+        clean_version = package.get('version').get('version', [''])[0]
+        given_pkg_version = get_version(pkg_name, clean_version, normalised_input_pkg_map)
+        pkg_recomendation = CABatchResponseBuilder(ecosystem). \
+            generate_recommendation(package, given_pkg_version)
+        stack_recommendation.append(pkg_recomendation)
+        known_package_flow(ecosystem, pkg_recomendation["package"], pkg_recomendation["version"])
+        db_known_packages.add(normlize_packages(pkg_name, clean_version,
+                                                given_version=given_pkg_version))
 
     input_dependencies = set(normalised_input_pkgs)
     unknown_pkgs: Set = input_dependencies.difference(db_known_packages)
     return stack_recommendation, unknown_pkgs
 
 
-def get_stack_recommendation(ecosystem, graph_response, normalised_input_pkgs):
-    """Get Stack Recommendation for All Ecosystems, Except Golang.
+def get_version(pkg_name: str, pkg_version: str, normalised_input_pkg_map=None) -> str:
+    """Output Package version for each Package.
 
-    Unlike Golang, No Multiple loops are required as "given_vr == version."
-    :param graph_response: Graph Response
-    :param normalised_input_pkgs: Input Packages.
-    :return: Stack Recomm. and DB_Known_Packages.
+    :param pkg_name: Package Name
+    :param normalised_input_pkg_map: Input Package Map
+    :param pkg_version: Clean Package Version
+    :return: Given Package version (By User)
     """
-    stack_recommendation = []
-    db_known_packages = set()
-    for package in graph_response.get('result', {}).get('data'):
-        pkg_name = package.get('package').get('name', [''])[0]
-        pkg_vr = package.get('version').get('version', [''])[0]
-        pkg_recomendation = CABatchResponseBuilder(ecosystem). \
-            generate_recommendation(package, pkg_vr)
-        stack_recommendation.append(pkg_recomendation)
-        known_package_flow(ecosystem, pkg_recomendation["package"], pkg_recomendation["version"])
-        db_known_packages.add(normlize_packages(pkg_name, pkg_vr,
-                                                given_version=pkg_vr))
-    return stack_recommendation, db_known_packages
-
-
-def get_stack_recommendation_for_golang(ecosystem, graph_response, normalised_input_pkgs):
-    """Get Stack Recommendation for Golang.
-
-    In Golang, we have to loop over normalised_input_pkgs to fetch
-    "given_version" and feed that to response builder.
-    :param ecosystem: Ecosystem
-    :param graph_response: Graph Response
-    :param normalised_input_pkgs: Input Packages.
-    :return: Stack Recomm. and DB_Known_Packages.
-    """
-    stack_recommendation = []
-    db_known_packages = set()
-    normalised_input_pkg_map = {input_pkg.name: input_pkg.given_version
-                                for input_pkg in normalised_input_pkgs}
-    for package in graph_response.get('result', {}).get('data'):
-        pkg_name = package.get('package').get('name', [''])[0]
-        pkg_vr = package.get('version').get('version', [''])[0]
-        pkg_recomendation = CABatchResponseBuilder(ecosystem). \
-            generate_recommendation(package, normalised_input_pkg_map[pkg_name])
-        stack_recommendation.append(pkg_recomendation)
-        db_known_packages.add(normlize_packages(pkg_name, pkg_vr,
-                                                given_version=normalised_input_pkg_map[pkg_name]))
-    return stack_recommendation, db_known_packages
+    logger.debug('Fetch Input Package version.')
+    if isinstance(normalised_input_pkg_map, dict):
+        return normalised_input_pkg_map[pkg_name]
+    return pkg_version
 
 
 def build_pkg_recommendation(pack_details, ecosystem) -> Dict:

--- a/bayesian/utility/v2/component_analyses.py
+++ b/bayesian/utility/v2/component_analyses.py
@@ -171,17 +171,16 @@ def get_stack_recommendation_for_golang(ecosystem, graph_response, normalised_in
     """
     stack_recommendation = []
     db_known_packages = set()
+    normalised_input_pkg_map = {input_pkg.name: input_pkg.given_version
+                                for input_pkg in normalised_input_pkgs}
     for package in graph_response.get('result', {}).get('data'):
-        for input_pkg in normalised_input_pkgs:
-            pkg_name = package.get('package').get('name', [''])[0]
-            pkg_vr = package.get('version').get('version', [''])[0]
-            if pkg_name != input_pkg.name:
-                continue
-            pkg_recomendation = CABatchResponseBuilder(ecosystem). \
-                generate_recommendation(package, input_pkg.given_version)
-            stack_recommendation.append(pkg_recomendation)
-            db_known_packages.add(normlize_packages(pkg_name, pkg_vr,
-                                                    given_version=input_pkg.given_version))
+        pkg_name = package.get('package').get('name', [''])[0]
+        pkg_vr = package.get('version').get('version', [''])[0]
+        pkg_recomendation = CABatchResponseBuilder(ecosystem). \
+            generate_recommendation(package, normalised_input_pkg_map[pkg_name])
+        stack_recommendation.append(pkg_recomendation)
+        db_known_packages.add(normlize_packages(pkg_name, pkg_vr,
+                                                given_version=normalised_input_pkg_map[pkg_name]))
     return stack_recommendation, db_known_packages
 
 


### PR DESCRIPTION
The issue was Input Package Order is not maintained by Gremlin which causes invalid Packages versions attached to different objects.

Issue: https://issues.redhat.com/browse/APPAI-1526

Signed-off-by: Deepak Sharma <deepshar@redhat.com>