### PR TITLE
[APPAI-1525] CA Response:  free-tier (In case of only security advisory) should not have the recommended version in CA response

### DIFF
--- a/bayesian/utility/v2/ca_response_builder.py
+++ b/bayesian/utility/v2/ca_response_builder.py
@@ -194,6 +194,20 @@ class ComponentResponseBase(ABC):
         """Abstract function for Generate Response.."""
         pass
 
+    def get_recommended_version(self):
+        """Return recommended version based on vulnerabilities and advisory count."""
+        '''
+        Show recommendation version for freetier user as per below flags:
+            1. known sec vuln > 0 & sec advisories > 0 --> recommendation = yes
+            2. known sec vuln > 0 & sec advisories = 0 --> recommendation = yes
+            3. known sec vuln = 0 & sec advisories > 0 --> recommendation = No
+            4. known sec vuln = 0 & sec advisories = 0 --> There will not be any vulnerability.
+        '''
+        if self.public_vul == 0:
+            return ''
+
+        return self.nocve_version
+
     def get_vulnerabilities_count(self):
         """Vulnerability count, Calculates Public and Pvt Vulnerability count.
 
@@ -344,7 +358,7 @@ class ComponentAnalysisResponseBuilder(ComponentResponseBase):
             vulnerability=self.get_cve_maps()
         )
         response = dict(
-            recommended_versions=self.nocve_version,
+            recommended_versions=self.get_recommended_version(),
             registration_link=self.get_registration_link(),
             component_analyses=component_analyses_dict,
             message=self.get_message(),
@@ -513,7 +527,7 @@ class CABatchResponseBuilder(ComponentResponseBase):
             package_unknown=False,
             package=self.package,
             version=self.version,
-            recommended_versions=self.nocve_version,
+            recommended_versions=self.get_recommended_version(),
             registration_link=self.get_registration_link(),
             vulnerability=self.get_cve_maps(),
             message=self.get_message(),

--- a/tests/utility/v2/test_ca_response_builder.py
+++ b/tests/utility/v2/test_ca_response_builder.py
@@ -325,6 +325,52 @@ class ComponentAnalysisResponseBuilderTest(unittest.TestCase):
         )
         self.assertDictEqual(response, mocked_response)
 
+    @patch('bayesian.utility.v2.ca_response_builder.'
+           'ComponentAnalysisResponseBuilder.get_cve_maps')
+    @patch('bayesian.utility.v2.ca_response_builder.'
+           'ComponentAnalysisResponseBuilder.get_registration_link')
+    @patch('bayesian.utility.v2.ca_response_builder.'
+           'ComponentAnalysisResponseBuilder.get_message')
+    def test_generate_response_rec_version(self, _mock_msg, _mock_link, _mock_maps):
+        """Test Response Generator Function."""
+        response_obj = ComponentAnalysisResponseBuilder(self.eco, self.pkg, self.ver)
+
+        _mock_msg.return_value = 'You are Superb.'
+        _mock_link.return_value = 'https://xyx.com'
+        _mock_maps.return_value = {}
+
+        response_obj.nocve_version = 1
+        response_obj.severity = ['high']
+        response_obj.public_vul = 2
+        response_obj.pvt_vul = 0
+        response = response_obj.generate_response()
+        mocked_response = dict(
+            recommended_versions=response_obj.nocve_version,
+            registration_link=_mock_link.return_value,
+            component_analyses=dict(vulnerability=_mock_maps.return_value),
+            message=_mock_msg.return_value,
+            severity=response_obj.severity[0],
+            known_security_vulnerability_count=response_obj.public_vul,
+            security_advisory_count=response_obj.pvt_vul,
+        )
+        self.assertDictEqual(response, mocked_response)
+
+        response_obj.public_vul = 1
+        response_obj.pvt_vul = 1
+        mocked_response['recommended_versions'] = response_obj.nocve_version
+        mocked_response['known_security_vulnerability_count'] = response_obj.public_vul
+        mocked_response['security_advisory_count'] = response_obj.pvt_vul
+        response = response_obj.generate_response()
+        self.assertDictEqual(response, mocked_response)
+
+        response_obj.public_vul = 0
+        response_obj.pvt_vul = 1
+        mocked_response['recommended_versions'] = ''
+        mocked_response['known_security_vulnerability_count'] = response_obj.public_vul
+        mocked_response['security_advisory_count'] = response_obj.pvt_vul
+        response = response_obj.generate_response()
+        self.assertDictEqual(response, mocked_response)
+
     def test_get_vulnerabilities_count_zero_exception(self):
         """Test Vulnerabilities count Exception."""
         response_obj = ComponentAnalysisResponseBuilder(self.eco, self.pkg, self.ver)


### PR DESCRIPTION
For freetier user , hide recommended version for '0' public vulnerability.

Jire Ticket :: https://issues.redhat.com/browse/APPAI-1525