### PR TITLE
chore: Unify python dependencies into requirements.in

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,10 +34,6 @@ RUN pushd /coreapi && \
     python3.6 -m pip install --upgrade pip>=10.0.0 && pip3 install . &&\
     popd
 
-RUN pip3 install git+https://github.com/fabric8-analytics/fabric8-analytics-worker.git@${F8A_WORKER_VERSION}
-RUN pip3 install git+https://github.com/fabric8-analytics/fabric8-analytics-auth.git@${F8A_AUTH_VERSION}
-RUN pip3 install git+https://github.com/fabric8-analytics/fabric8-analytics-utils.git@${F8A_UTILS}
-RUN pip3 install git+https://github.com/fabric8-analytics/fabric8-analytics-version-comparator.git#egg=f8a_version_comparator
 
 # Required by the solver task in worker to resolve dependencies from package.json
 RUN npm install -g semver-ranger

--- a/Dockerfile.rhel
+++ b/Dockerfile.rhel
@@ -27,10 +27,6 @@ RUN pushd /coreapi && \
     pip3 install --upgrade pip>=10.0.0 && pip3 install . &&\
     popd
 
-RUN pip3 install git+https://github.com/fabric8-analytics/fabric8-analytics-worker.git@${F8A_WORKER_VERSION}
-RUN pip3 install git+https://github.com/fabric8-analytics/fabric8-analytics-auth.git@${F8A_AUTH_VERSION}
-RUN pip3 install git+https://github.com/fabric8-analytics/fabric8-analytics-utils.git@${F8A_UTILS}
-RUN pip3 install git+https://github.com/fabric8-analytics/fabric8-analytics-version-comparator.git#egg=f8a_version_comparator
 
 # Required by the solver task in worker to resolve dependencies from package.json
 RUN npm install -g semver-ranger

--- a/requirements.in
+++ b/requirements.in
@@ -1,28 +1,17 @@
-flask
-flask-appconfig>=0.10
-flask-security
-flask-sqlalchemy
-flask-restful
-flask-cors
-jsl
-# there's a regression in mod_wsgi 4.5.4:
-# https://github.com/GrahamDumpleton/mod_wsgi/issues/147
-# install httpd-devel in order to have apxs command, otherwise build fails
-mod_wsgi!=4.5.4
-psycopg2-binary
-# in order for pyjwt to be able to use RS256 we need pycrypto
-cryptography
-pyjwt>=1.6.1
-requests-futures
-Flask-Cache
-semantic_version
-py_lru_cache
-radon==3.0.1
-pygithub
-codecov
-lxml
-gitpython
-raven[flask]
-pydantic
 tenacity
-semver
+Werkzeug
+Flask_Cors
+Flask_SQLAlchemy
+Flask
+flask_appconfig
+py_lru_cache
+lxml
+requests
+SQLAlchemy
+raven
+pydantic
+pytest
+Flask_Cache
+Flask_RESTful
+requests_futures
+semantic_version

--- a/requirements.in
+++ b/requirements.in
@@ -1,15 +1,11 @@
 tenacity
-Werkzeug
 Flask_Cors
 Flask_SQLAlchemy
 Flask
 flask_appconfig
 py_lru_cache
-lxml
 requests
-SQLAlchemy
 raven
-pydantic
 Flask_Cache
 Flask_RESTful
 requests_futures
@@ -20,11 +16,11 @@ semantic_version
 mod_wsgi!=4.5.4
 flask
 flask-appconfig>=0.10
-pydantic
 blinker
 pygithub
+pydantic
 psycopg2-binary
-f8a_version_comparator @ git+https://github.com/fabric8-analytics/fabric8-analytics-version-comparator.git@8a57ac7#egg=f8a_version_comparator
-f8a_worker-version @ git+https://github.com/fabric8-analytics/fabric8-analytics-worker.git@066c2f6#egg=F8A_WORKER_VERSION
-f8a_auth_version @ git+https://github.com/fabric8-analytics/fabric8-analytics-auth.git@5ff9438#egg=F8A_AUTH_VERSION
-f8a_utils @ git+https://github.com/fabric8-analytics/fabric8-analytics-utils.git@5a5ce60#egg=F8A_UTILS
+f8a_worker-version @ git+https://github.com/fabric8-analytics/fabric8-analytics-worker.git@066c2f6#egg=f8a_worker
+f8a_auth_version @ git+https://github.com/fabric8-analytics/fabric8-analytics-auth.git@5ff9438#egg=fabric8a_auth
+f8a_utils @ git+https://github.com/fabric8-analytics/fabric8-analytics-utils.git@5a5ce60#egg=f8a_utils
+

--- a/requirements.in
+++ b/requirements.in
@@ -15,3 +15,12 @@ Flask_Cache
 Flask_RESTful
 requests_futures
 semantic_version
+# there's a regression in mod_wsgi 4.5.4:
+# https://github.com/GrahamDumpleton/mod_wsgi/issues/147
+# install httpd-devel in order to have apxs command, otherwise build fails
+mod_wsgi!=4.5.4
+flask
+flask-appconfig>=0.10
+pydantic
+blinker
+pygithub

--- a/requirements.in
+++ b/requirements.in
@@ -24,3 +24,8 @@ flask-appconfig>=0.10
 pydantic
 blinker
 pygithub
+psycopg2-binary
+git+https://github.com/fabric8-analytics/fabric8-analytics-worker.git#egg=F8A_WORKER_VERSION
+git+https://github.com/fabric8-analytics/fabric8-analytics-auth.git#egg=F8A_AUTH_VERSION
+git+https://github.com/fabric8-analytics/fabric8-analytics-utils.git#egg=F8A_UTILS
+git+https://github.com/fabric8-analytics/fabric8-analytics-version-comparator.git#egg=f8a_version_comparator

--- a/requirements.in
+++ b/requirements.in
@@ -10,7 +10,6 @@ requests
 SQLAlchemy
 raven
 pydantic
-pytest
 Flask_Cache
 Flask_RESTful
 requests_futures
@@ -25,7 +24,7 @@ pydantic
 blinker
 pygithub
 psycopg2-binary
-git+https://github.com/fabric8-analytics/fabric8-analytics-worker.git#egg=F8A_WORKER_VERSION
-git+https://github.com/fabric8-analytics/fabric8-analytics-auth.git#egg=F8A_AUTH_VERSION
-git+https://github.com/fabric8-analytics/fabric8-analytics-utils.git#egg=F8A_UTILS
-git+https://github.com/fabric8-analytics/fabric8-analytics-version-comparator.git#egg=f8a_version_comparator
+f8a_version_comparator @ git+https://github.com/fabric8-analytics/fabric8-analytics-version-comparator.git@8a57ac7#egg=f8a_version_comparator
+f8a_worker-version @ git+https://github.com/fabric8-analytics/fabric8-analytics-worker.git@066c2f6#egg=F8A_WORKER_VERSION
+f8a_auth_version @ git+https://github.com/fabric8-analytics/fabric8-analytics-auth.git@5ff9438#egg=F8A_AUTH_VERSION
+f8a_utils @ git+https://github.com/fabric8-analytics/fabric8-analytics-utils.git@5a5ce60#egg=F8A_UTILS

--- a/requirements.in
+++ b/requirements.in
@@ -1,26 +1,34 @@
-tenacity
-Flask_Cors
-Flask_SQLAlchemy
+Werkzeug
 Flask
-flask_appconfig
-py_lru_cache
 requests
+botocore
+flask_appconfig
+flask_cache
+flask_cors
+flask_restful
+flask_sqlalchemy
+GitPython
+py_lru_cache
+lxml
+pydantic
+PyGithub
 raven
-Flask_Cache
-Flask_RESTful
 requests_futures
+selinon
 semantic_version
+SQLAlchemy
+tenacity
+
+#packages discovered after running the image on cluster
+psycopg2-binary
+
 # there's a regression in mod_wsgi 4.5.4:
 # https://github.com/GrahamDumpleton/mod_wsgi/issues/147
 # install httpd-devel in order to have apxs command, otherwise build fails
 mod_wsgi!=4.5.4
-flask
-flask-appconfig>=0.10
-blinker
-pygithub
-pydantic
-psycopg2-binary
-f8a_worker-version @ git+https://github.com/fabric8-analytics/fabric8-analytics-worker.git@066c2f6#egg=f8a_worker
-f8a_auth_version @ git+https://github.com/fabric8-analytics/fabric8-analytics-auth.git@5ff9438#egg=fabric8a_auth
+
+
+f8a_worker @ git+https://github.com/fabric8-analytics/fabric8-analytics-worker.git@066c2f6#egg=f8a_worker
+f8a_auth @ git+https://github.com/fabric8-analytics/fabric8-analytics-auth.git@5ff9438#egg=fabric8a_auth
 f8a_utils @ git+https://github.com/fabric8-analytics/fabric8-analytics-utils.git@5a5ce60#egg=f8a_utils
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,68 +4,40 @@
 #
 #    pip-compile --output-file=requirements.txt requirements.in
 #
-aniso8601==6.0.0          # via flask-restful
-asn1crypto==0.24.0        # via cryptography
-babel==2.6.0              # via flask-babelex
-blinker==1.4              # via flask-mail, flask-principal, raven
-certifi==2019.3.9         # via requests
-cffi==1.12.2              # via cryptography
+aniso8601==8.0.0          # via flask-restful
+attrs==20.3.0             # via pytest
+certifi==2020.11.8        # via requests
 chardet==3.0.4            # via requests
-click==7.0                # via flask, flask-appconfig
-codecov==2.1.10           # via -r requirements.in
-colorama==0.4.1           # via radon
-coverage==4.5.3           # via codecov
-cryptography==3.2.1       # via -r requirements.in
-dataclasses==0.7          # via pydantic
-deprecated==1.2.5         # via pygithub
-entrypoints==0.3          # via flake8
-flake8-polyfill==1.0.2    # via radon
-flake8==3.7.7             # via flake8-polyfill
+click==7.1.2              # via flask, flask-appconfig
 flask-appconfig==0.11.1   # via -r requirements.in
-flask-babelex==0.9.3      # via flask-security
 flask-cache==0.13.1       # via -r requirements.in
 flask-cors==3.0.9         # via -r requirements.in
-flask-login==0.4.1        # via flask-security
-flask-mail==0.9.1         # via flask-security
-flask-principal==0.4.0    # via flask-security
-flask-restful==0.3.7      # via -r requirements.in
-flask-security==3.0.0     # via -r requirements.in
-flask-sqlalchemy==2.3.2   # via -r requirements.in
-flask-wtf==0.14.2         # via flask-security
-flask==0.12.4             # via -r requirements.in, flask-appconfig, flask-babelex, flask-cache, flask-cors, flask-login, flask-mail, flask-principal, flask-restful, flask-security, flask-sqlalchemy, flask-wtf, raven
-gitdb2==2.0.5             # via gitpython
-gitpython==2.1.11         # via -r requirements.in
-idna==2.8                 # via requests
-itsdangerous==1.1.0       # via flask, flask-security
-jinja2==2.10.1            # via flask, flask-babelex
-jsl==0.2.4                # via -r requirements.in
-lxml==4.3.3               # via -r requirements.in
-mando==0.6.4              # via radon
+flask-restful==0.3.8      # via -r requirements.in
+flask-sqlalchemy==2.4.4   # via -r requirements.in
+flask==0.12.5             # via -r requirements.in, flask-appconfig, flask-cache, flask-cors, flask-restful, flask-sqlalchemy
+idna==2.10                # via requests
+importlib-metadata==2.0.0  # via pluggy, pytest
+iniconfig==1.1.1          # via pytest
+itsdangerous==1.1.0       # via flask
+jinja2==2.11.2            # via flask
+lxml==4.6.1               # via -r requirements.in
 markupsafe==1.1.1         # via jinja2
-mccabe==0.6.1             # via flake8
-mod-wsgi==4.6.5           # via -r requirements.in
-passlib==1.7.4            # via flask-security
-psycopg2-binary==2.8.6    # via -r requirements.in
+packaging==20.4           # via pytest
+pluggy==0.13.1            # via pytest
 py-lru-cache==0.1.4       # via -r requirements.in
-pycodestyle==2.5.0        # via flake8
-pycparser==2.19           # via cffi
-pydantic==1.5.1           # via -r requirements.in
-pyflakes==2.1.1           # via flake8
-pygithub==1.43.6          # via -r requirements.in
-pyjwt==1.7.1              # via -r requirements.in, pygithub
-pytz==2019.1              # via babel, flask-restful
-radon==3.0.1              # via -r requirements.in
-raven[flask]==6.10.0      # via -r requirements.in
-requests-futures==0.9.9   # via -r requirements.in
-requests==2.21.0          # via codecov, pygithub, requests-futures
-semantic-version==2.6.0   # via -r requirements.in
-semver==2.10.2            # via -r requirements.in
-six==1.12.0               # via cryptography, flask-appconfig, flask-cors, flask-restful, mando, tenacity
-smmap2==2.0.5             # via gitdb2
-speaklater==1.3           # via flask-babelex
-sqlalchemy==1.3.20         # via flask-sqlalchemy
+py==1.9.0                 # via pytest
+pydantic==1.7.2           # via -r requirements.in
+pyparsing==2.4.7          # via packaging
+pytest==6.1.2             # via -r requirements.in
+pytz==2020.4              # via flask-restful
+raven==6.10.0             # via -r requirements.in
+requests-futures==1.0.0   # via -r requirements.in
+requests==2.25.0          # via -r requirements.in, requests-futures
+semantic-version==2.8.5   # via -r requirements.in
+six==1.15.0               # via flask-appconfig, flask-cors, flask-restful, packaging, tenacity
+sqlalchemy==1.3.20        # via -r requirements.in, flask-sqlalchemy
 tenacity==6.2.0           # via -r requirements.in
-urllib3==1.25.11           # via requests
-werkzeug==1.0.1         # via flask
-wrapt==1.11.1             # via deprecated
-wtforms==2.2.1            # via flask-wtf
+toml==0.10.2              # via pytest
+urllib3==1.26.2           # via requests
+werkzeug==0.16.1          # via -r requirements.in, flask
+zipp==3.4.0               # via importlib-metadata

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,9 +6,11 @@
 #
 aniso8601==8.0.0          # via flask-restful
 attrs==20.3.0             # via pytest
+blinker==1.4              # via -r requirements.in
 certifi==2020.11.8        # via requests
 chardet==3.0.4            # via requests
 click==7.1.2              # via flask, flask-appconfig
+deprecated==1.2.10        # via pygithub
 flask-appconfig==0.11.1   # via -r requirements.in
 flask-cache==0.13.1       # via -r requirements.in
 flask-cors==3.0.9         # via -r requirements.in
@@ -22,17 +24,20 @@ itsdangerous==1.1.0       # via flask
 jinja2==2.11.2            # via flask
 lxml==4.6.1               # via -r requirements.in
 markupsafe==1.1.1         # via jinja2
+mod-wsgi==4.7.1           # via -r requirements.in
 packaging==20.4           # via pytest
 pluggy==0.13.1            # via pytest
 py-lru-cache==0.1.4       # via -r requirements.in
 py==1.9.0                 # via pytest
 pydantic==1.7.2           # via -r requirements.in
+pygithub==1.53            # via -r requirements.in
+pyjwt==1.7.1              # via pygithub
 pyparsing==2.4.7          # via packaging
 pytest==6.1.2             # via -r requirements.in
 pytz==2020.4              # via flask-restful
 raven==6.10.0             # via -r requirements.in
 requests-futures==1.0.0   # via -r requirements.in
-requests==2.25.0          # via -r requirements.in, requests-futures
+requests==2.25.0          # via -r requirements.in, pygithub, requests-futures
 semantic-version==2.8.5   # via -r requirements.in
 six==1.15.0               # via flask-appconfig, flask-cors, flask-restful, packaging, tenacity
 sqlalchemy==1.3.20        # via -r requirements.in, flask-sqlalchemy
@@ -40,4 +45,5 @@ tenacity==6.2.0           # via -r requirements.in
 toml==0.10.2              # via pytest
 urllib3==1.26.2           # via requests
 werkzeug==0.16.1          # via -r requirements.in, flask
+wrapt==1.12.1             # via deprecated
 zipp==3.4.0               # via importlib-metadata

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ amqp==5.0.2               # via kombu
 aniso8601==8.0.0          # via flask-restful
 anymarkup-core==0.8.1     # via anymarkup
 anymarkup==0.8.1          # via f8a-worker
-attrs==20.3.0             # via jsonschema, pytest
+attrs==20.3.0             # via jsonschema
 babel==2.9.0              # via flask-babelex
 beautifulsoup4==4.9.3     # via bs4, f8a-worker
 billiard==3.6.3.0         # via celery
@@ -28,10 +28,10 @@ colorama==0.4.4           # via rainbow-logging-handler
 configobj==5.0.6          # via anymarkup
 cryptography==3.2.1       # via f8a-utils, fabric8a-auth
 deprecated==1.2.10        # via pygithub
-git+https://github.com/fabric8-analytics/fabric8-analytics-worker.git@066c2f6#egg=F8A_WORKER_VERSION  # via -r requirements.in
-git+https://github.com/fabric8-analytics/fabric8-analytics-utils.git@5a5ce60#egg=F8A_UTILS  # via -r requirements.in, f8a-worker
-git+https://github.com/fabric8-analytics/fabric8-analytics-version-comparator.git@8a57ac7#egg=f8a_version_comparator  # via -r requirements.in, f8a-utils
-git+https://github.com/fabric8-analytics/fabric8-analytics-auth.git@5ff9438#egg=F8A_AUTH_VERSION  # via -r requirements.in
+git+https://github.com/fabric8-analytics/fabric8-analytics-worker.git@066c2f6#egg=f8a_worker  # via -r requirements.in
+git+https://github.com/fabric8-analytics/fabric8-analytics-utils.git@5a5ce60#egg=f8a_utils  # via -r requirements.in, f8a-worker
+git+https://github.com/fabric8-analytics/fabric8-analytics-version-comparator.git@8a57ac7#egg=f8a_version_comparator  # via f8a-utils
+git+https://github.com/fabric8-analytics/fabric8-analytics-auth.git@5ff9438#egg=fabric8a_auth  # via -r requirements.in
 flask-appconfig==0.11.1   # via -r requirements.in
 flask-babelex==0.9.4      # via flask-security
 flask-cache==0.13.1       # via -r requirements.in
@@ -49,8 +49,7 @@ gitdb==4.0.5              # via gitpython
 gitpython==3.1.11         # via f8a-worker
 graphviz==0.15            # via selinon
 idna==2.10                # via requests
-importlib-metadata==3.1.0  # via jsonschema, kombu, pluggy, pytest
-iniconfig==1.1.1          # via pytest
+importlib-metadata==3.1.0  # via jsonschema, kombu
 itsdangerous==1.1.0       # via flask, flask-security, flask-wtf
 jinja2==2.11.2            # via flask, flask-babelex
 jmespath==0.10.0          # via boto3, botocore
@@ -59,23 +58,18 @@ json5==0.9.5              # via anymarkup
 jsonschema==3.2.0         # via f8a-worker, selinon
 kombu==5.0.2              # via celery
 logutils==0.3.5           # via rainbow-logging-handler
-lxml==4.6.1               # via -r requirements.in, f8a-utils, f8a-worker
+lxml==4.6.1               # via f8a-utils, f8a-worker
 markupsafe==1.1.1         # via jinja2, wtforms
 mod-wsgi==4.7.1           # via -r requirements.in
-packaging==20.4           # via pytest
 passlib==1.7.4            # via flask-security
-pluggy==0.13.1            # via pytest
 prompt-toolkit==3.0.8     # via click-repl
 psycopg2-binary==2.8.6    # via -r requirements.in
 py-lru-cache==0.1.4       # via -r requirements.in
-py==1.9.0                 # via pytest
 pycparser==2.20           # via cffi
 pydantic==1.7.2           # via -r requirements.in
 pygithub==1.53            # via -r requirements.in
 pyjwt==1.7.1              # via fabric8a-auth, pygithub
-pyparsing==2.4.7          # via packaging
 pyrsistent==0.17.3        # via jsonschema
-pytest==6.1.2             # via -r requirements.in
 python-dateutil==2.8.1    # via botocore
 pytz==2020.4              # via babel, celery, flask-restful
 pyyaml==5.3.1             # via anymarkup, f8a-worker, selinon
@@ -87,17 +81,17 @@ s3transfer==0.3.3         # via boto3
 selinon[celery]==1.0.0    # via f8a-worker
 semantic-version==2.8.5   # via -r requirements.in, f8a-worker
 semver==2.13.0            # via f8a-utils
-six==1.15.0               # via anymarkup-core, click-repl, configobj, cryptography, flask-appconfig, flask-cors, flask-restful, jsonschema, packaging, python-dateutil, tenacity
+six==1.15.0               # via anymarkup-core, click-repl, configobj, cryptography, flask-appconfig, flask-cors, flask-restful, jsonschema, python-dateutil, tenacity
 smmap==3.0.4              # via gitdb
 soupsieve==2.0.1          # via beautifulsoup4
 speaklater==1.3           # via flask-babelex
-sqlalchemy==1.3.20        # via -r requirements.in, f8a-worker, flask-sqlalchemy
+sqlalchemy==1.3.20        # via f8a-worker, flask-sqlalchemy
 tenacity==6.2.0           # via -r requirements.in, f8a-utils, f8a-worker
-toml==0.9.4               # via anymarkup, f8a-worker, pytest
+toml==0.9.4               # via anymarkup, f8a-worker
 urllib3==1.26.2           # via botocore, requests
 vine==5.0.0               # via amqp, celery
 wcwidth==0.2.5            # via prompt-toolkit
-werkzeug==0.16.1          # via -r requirements.in, f8a-worker, flask
+werkzeug==0.16.1          # via f8a-worker, flask
 wrapt==1.12.1             # via deprecated
 wtforms==2.3.3            # via flask-wtf
 xmltodict==0.12.0         # via anymarkup

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,8 +13,8 @@ babel==2.9.0              # via flask-babelex
 beautifulsoup4==4.9.3     # via bs4, f8a-worker
 billiard==3.6.3.0         # via celery
 blinker==1.4              # via -r requirements.in, flask-mail, flask-principal
-boto3==1.16.23            # via f8a-worker
-botocore==1.19.23         # via boto3, f8a-worker, s3transfer
+boto3==1.16.24            # via f8a-worker
+botocore==1.19.24         # via boto3, f8a-worker, s3transfer
 bs4==0.0.1                # via f8a-utils
 celery==5.0.2             # via selinon
 certifi==2020.11.8        # via requests
@@ -28,10 +28,10 @@ colorama==0.4.4           # via rainbow-logging-handler
 configobj==5.0.6          # via anymarkup
 cryptography==3.2.1       # via f8a-utils, fabric8a-auth
 deprecated==1.2.10        # via pygithub
-git+https://github.com/fabric8-analytics/fabric8-analytics-worker.git#egg=F8A_WORKER_VERSION  # via -r requirements.in
-git+https://github.com/fabric8-analytics/fabric8-analytics-utils.git#egg=F8A_UTILS  # via -r requirements.in, f8a-worker
-git+https://github.com/fabric8-analytics/fabric8-analytics-version-comparator.git#egg=f8a_version_comparator  # via -r requirements.in, f8a-utils
-git+https://github.com/fabric8-analytics/fabric8-analytics-auth.git#egg=F8A_AUTH_VERSION  # via -r requirements.in
+git+https://github.com/fabric8-analytics/fabric8-analytics-worker.git@066c2f6#egg=F8A_WORKER_VERSION  # via -r requirements.in
+git+https://github.com/fabric8-analytics/fabric8-analytics-utils.git@5a5ce60#egg=F8A_UTILS  # via -r requirements.in, f8a-worker
+git+https://github.com/fabric8-analytics/fabric8-analytics-version-comparator.git@8a57ac7#egg=f8a_version_comparator  # via -r requirements.in, f8a-utils
+git+https://github.com/fabric8-analytics/fabric8-analytics-auth.git@5ff9438#egg=F8A_AUTH_VERSION  # via -r requirements.in
 flask-appconfig==0.11.1   # via -r requirements.in
 flask-babelex==0.9.4      # via flask-security
 flask-cache==0.13.1       # via -r requirements.in
@@ -49,7 +49,7 @@ gitdb==4.0.5              # via gitpython
 gitpython==3.1.11         # via f8a-worker
 graphviz==0.15            # via selinon
 idna==2.10                # via requests
-importlib-metadata==2.0.0  # via jsonschema, kombu, pluggy, pytest
+importlib-metadata==3.1.0  # via jsonschema, kombu, pluggy, pytest
 iniconfig==1.1.1          # via pytest
 itsdangerous==1.1.0       # via flask, flask-security, flask-wtf
 jinja2==2.11.2            # via flask, flask-babelex

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,13 +12,13 @@ attrs==20.3.0             # via jsonschema
 babel==2.9.0              # via flask-babelex
 beautifulsoup4==4.9.3     # via bs4, f8a-worker
 billiard==3.6.3.0         # via celery
-blinker==1.4              # via -r requirements.in, flask-mail, flask-principal
-boto3==1.16.24            # via f8a-worker
-botocore==1.19.24         # via boto3, f8a-worker, s3transfer
+blinker==1.4              # via flask-mail, flask-principal
+boto3==1.16.25            # via f8a-worker
+botocore==1.19.25         # via -r requirements.in, boto3, f8a-worker, s3transfer
 bs4==0.0.1                # via f8a-utils
 celery==5.0.2             # via selinon
 certifi==2020.11.8        # via requests
-cffi==1.14.3              # via cryptography
+cffi==1.14.4              # via cryptography
 chardet==3.0.4            # via requests
 click-didyoumean==0.0.3   # via celery
 click-repl==0.1.6         # via celery
@@ -28,9 +28,9 @@ colorama==0.4.4           # via rainbow-logging-handler
 configobj==5.0.6          # via anymarkup
 cryptography==3.2.1       # via f8a-utils, fabric8a-auth
 deprecated==1.2.10        # via pygithub
-git+https://github.com/fabric8-analytics/fabric8-analytics-worker.git@066c2f6#egg=f8a_worker  # via -r requirements.in
 git+https://github.com/fabric8-analytics/fabric8-analytics-utils.git@5a5ce60#egg=f8a_utils  # via -r requirements.in, f8a-worker
 git+https://github.com/fabric8-analytics/fabric8-analytics-version-comparator.git@8a57ac7#egg=f8a_version_comparator  # via f8a-utils
+git+https://github.com/fabric8-analytics/fabric8-analytics-worker.git@066c2f6#egg=f8a_worker  # via -r requirements.in
 git+https://github.com/fabric8-analytics/fabric8-analytics-auth.git@5ff9438#egg=fabric8a_auth  # via -r requirements.in
 flask-appconfig==0.11.1   # via -r requirements.in
 flask-babelex==0.9.4      # via flask-security
@@ -46,7 +46,7 @@ flask-wtf==0.14.3         # via flask-security
 flask==0.12.5             # via -r requirements.in, fabric8a-auth, flask-appconfig, flask-babelex, flask-cache, flask-cors, flask-login, flask-mail, flask-principal, flask-restful, flask-security, flask-sqlalchemy, flask-wtf
 git2json==0.2.3           # via f8a-worker
 gitdb==4.0.5              # via gitpython
-gitpython==3.1.11         # via f8a-worker
+gitpython==3.1.11         # via -r requirements.in, f8a-worker
 graphviz==0.15            # via selinon
 idna==2.10                # via requests
 importlib-metadata==3.1.0  # via jsonschema, kombu
@@ -58,7 +58,7 @@ json5==0.9.5              # via anymarkup
 jsonschema==3.2.0         # via f8a-worker, selinon
 kombu==5.0.2              # via celery
 logutils==0.3.5           # via rainbow-logging-handler
-lxml==4.6.1               # via f8a-utils, f8a-worker
+lxml==4.6.1               # via -r requirements.in, f8a-utils, f8a-worker
 markupsafe==1.1.1         # via jinja2, wtforms
 mod-wsgi==4.7.1           # via -r requirements.in
 passlib==1.7.4            # via flask-security
@@ -78,20 +78,20 @@ raven==6.10.0             # via -r requirements.in, f8a-worker
 requests-futures==1.0.0   # via -r requirements.in, f8a-worker
 requests==2.25.0          # via -r requirements.in, f8a-utils, f8a-worker, fabric8a-auth, pygithub, requests-futures
 s3transfer==0.3.3         # via boto3
-selinon[celery]==1.0.0    # via f8a-worker
+selinon==1.0.0            # via -r requirements.in, f8a-worker
 semantic-version==2.8.5   # via -r requirements.in, f8a-worker
 semver==2.13.0            # via f8a-utils
 six==1.15.0               # via anymarkup-core, click-repl, configobj, cryptography, flask-appconfig, flask-cors, flask-restful, jsonschema, python-dateutil, tenacity
 smmap==3.0.4              # via gitdb
 soupsieve==2.0.1          # via beautifulsoup4
 speaklater==1.3           # via flask-babelex
-sqlalchemy==1.3.20        # via f8a-worker, flask-sqlalchemy
+sqlalchemy==1.3.20        # via -r requirements.in, f8a-worker, flask-sqlalchemy
 tenacity==6.2.0           # via -r requirements.in, f8a-utils, f8a-worker
 toml==0.9.4               # via anymarkup, f8a-worker
 urllib3==1.26.2           # via botocore, requests
 vine==5.0.0               # via amqp, celery
 wcwidth==0.2.5            # via prompt-toolkit
-werkzeug==0.16.1          # via f8a-worker, flask
+werkzeug==0.16.1          # via -r requirements.in, f8a-worker, flask
 wrapt==1.12.1             # via deprecated
 wtforms==2.3.3            # via flask-wtf
 xmltodict==0.12.0         # via anymarkup

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,10 +12,10 @@ certifi==2019.3.9         # via requests
 cffi==1.12.2              # via cryptography
 chardet==3.0.4            # via requests
 click==7.0                # via flask, flask-appconfig
-codecov==2.0.15           # via -r requirements.in
+codecov==2.1.10           # via -r requirements.in
 colorama==0.4.1           # via radon
 coverage==4.5.3           # via codecov
-cryptography==2.6.1       # via -r requirements.in
+cryptography==3.2.1       # via -r requirements.in
 dataclasses==0.7          # via pydantic
 deprecated==1.2.5         # via pygithub
 entrypoints==0.3          # via flake8
@@ -24,7 +24,7 @@ flake8==3.7.7             # via flake8-polyfill
 flask-appconfig==0.11.1   # via -r requirements.in
 flask-babelex==0.9.3      # via flask-security
 flask-cache==0.13.1       # via -r requirements.in
-flask-cors==3.0.7         # via -r requirements.in
+flask-cors==3.0.9         # via -r requirements.in
 flask-login==0.4.1        # via flask-security
 flask-mail==0.9.1         # via flask-security
 flask-principal==0.4.0    # via flask-security
@@ -44,7 +44,7 @@ mando==0.6.4              # via radon
 markupsafe==1.1.1         # via jinja2
 mccabe==0.6.1             # via flake8
 mod-wsgi==4.6.5           # via -r requirements.in
-passlib==1.7.1            # via flask-security
+passlib==1.7.4            # via flask-security
 psycopg2-binary==2.8.6    # via -r requirements.in
 py-lru-cache==0.1.4       # via -r requirements.in
 pycodestyle==2.5.0        # via flake8
@@ -63,9 +63,9 @@ semver==2.10.2            # via -r requirements.in
 six==1.12.0               # via cryptography, flask-appconfig, flask-cors, flask-restful, mando, tenacity
 smmap2==2.0.5             # via gitdb2
 speaklater==1.3           # via flask-babelex
-sqlalchemy==1.3.2         # via flask-sqlalchemy
+sqlalchemy==1.3.20         # via flask-sqlalchemy
 tenacity==6.2.0           # via -r requirements.in
-urllib3==1.24.1           # via requests
-werkzeug==0.15.2          # via flask
+urllib3==1.25.11           # via requests
+werkzeug==1.0.1         # via flask
 wrapt==1.11.1             # via deprecated
 wtforms==2.2.1            # via flask-wtf

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,46 +4,104 @@
 #
 #    pip-compile --output-file=requirements.txt requirements.in
 #
+amqp==5.0.2               # via kombu
 aniso8601==8.0.0          # via flask-restful
-attrs==20.3.0             # via pytest
-blinker==1.4              # via -r requirements.in
+anymarkup-core==0.8.1     # via anymarkup
+anymarkup==0.8.1          # via f8a-worker
+attrs==20.3.0             # via jsonschema, pytest
+babel==2.9.0              # via flask-babelex
+beautifulsoup4==4.9.3     # via bs4, f8a-worker
+billiard==3.6.3.0         # via celery
+blinker==1.4              # via -r requirements.in, flask-mail, flask-principal
+boto3==1.16.23            # via f8a-worker
+botocore==1.19.23         # via boto3, f8a-worker, s3transfer
+bs4==0.0.1                # via f8a-utils
+celery==5.0.2             # via selinon
 certifi==2020.11.8        # via requests
+cffi==1.14.3              # via cryptography
 chardet==3.0.4            # via requests
-click==7.1.2              # via flask, flask-appconfig
+click-didyoumean==0.0.3   # via celery
+click-repl==0.1.6         # via celery
+click==7.1.2              # via anymarkup, celery, click-didyoumean, click-repl, flask, flask-appconfig, selinon
+codegen==1.0              # via selinon
+colorama==0.4.4           # via rainbow-logging-handler
+configobj==5.0.6          # via anymarkup
+cryptography==3.2.1       # via f8a-utils, fabric8a-auth
 deprecated==1.2.10        # via pygithub
+git+https://github.com/fabric8-analytics/fabric8-analytics-worker.git#egg=F8A_WORKER_VERSION  # via -r requirements.in
+git+https://github.com/fabric8-analytics/fabric8-analytics-utils.git#egg=F8A_UTILS  # via -r requirements.in, f8a-worker
+git+https://github.com/fabric8-analytics/fabric8-analytics-version-comparator.git#egg=f8a_version_comparator  # via -r requirements.in, f8a-utils
+git+https://github.com/fabric8-analytics/fabric8-analytics-auth.git#egg=F8A_AUTH_VERSION  # via -r requirements.in
 flask-appconfig==0.11.1   # via -r requirements.in
+flask-babelex==0.9.4      # via flask-security
 flask-cache==0.13.1       # via -r requirements.in
 flask-cors==3.0.9         # via -r requirements.in
+flask-login==0.5.0        # via flask-security
+flask-mail==0.9.1         # via flask-security
+flask-principal==0.4.0    # via flask-security
 flask-restful==0.3.8      # via -r requirements.in
+flask-security==3.0.0     # via fabric8a-auth
 flask-sqlalchemy==2.4.4   # via -r requirements.in
-flask==0.12.5             # via -r requirements.in, flask-appconfig, flask-cache, flask-cors, flask-restful, flask-sqlalchemy
+flask-wtf==0.14.3         # via flask-security
+flask==0.12.5             # via -r requirements.in, fabric8a-auth, flask-appconfig, flask-babelex, flask-cache, flask-cors, flask-login, flask-mail, flask-principal, flask-restful, flask-security, flask-sqlalchemy, flask-wtf
+git2json==0.2.3           # via f8a-worker
+gitdb==4.0.5              # via gitpython
+gitpython==3.1.11         # via f8a-worker
+graphviz==0.15            # via selinon
 idna==2.10                # via requests
-importlib-metadata==2.0.0  # via pluggy, pytest
+importlib-metadata==2.0.0  # via jsonschema, kombu, pluggy, pytest
 iniconfig==1.1.1          # via pytest
-itsdangerous==1.1.0       # via flask
-jinja2==2.11.2            # via flask
-lxml==4.6.1               # via -r requirements.in
-markupsafe==1.1.1         # via jinja2
+itsdangerous==1.1.0       # via flask, flask-security, flask-wtf
+jinja2==2.11.2            # via flask, flask-babelex
+jmespath==0.10.0          # via boto3, botocore
+jsl==0.2.4                # via f8a-worker
+json5==0.9.5              # via anymarkup
+jsonschema==3.2.0         # via f8a-worker, selinon
+kombu==5.0.2              # via celery
+logutils==0.3.5           # via rainbow-logging-handler
+lxml==4.6.1               # via -r requirements.in, f8a-utils, f8a-worker
+markupsafe==1.1.1         # via jinja2, wtforms
 mod-wsgi==4.7.1           # via -r requirements.in
 packaging==20.4           # via pytest
+passlib==1.7.4            # via flask-security
 pluggy==0.13.1            # via pytest
+prompt-toolkit==3.0.8     # via click-repl
+psycopg2-binary==2.8.6    # via -r requirements.in
 py-lru-cache==0.1.4       # via -r requirements.in
 py==1.9.0                 # via pytest
+pycparser==2.20           # via cffi
 pydantic==1.7.2           # via -r requirements.in
 pygithub==1.53            # via -r requirements.in
-pyjwt==1.7.1              # via pygithub
+pyjwt==1.7.1              # via fabric8a-auth, pygithub
 pyparsing==2.4.7          # via packaging
+pyrsistent==0.17.3        # via jsonschema
 pytest==6.1.2             # via -r requirements.in
-pytz==2020.4              # via flask-restful
-raven==6.10.0             # via -r requirements.in
-requests-futures==1.0.0   # via -r requirements.in
-requests==2.25.0          # via -r requirements.in, pygithub, requests-futures
-semantic-version==2.8.5   # via -r requirements.in
-six==1.15.0               # via flask-appconfig, flask-cors, flask-restful, packaging, tenacity
-sqlalchemy==1.3.20        # via -r requirements.in, flask-sqlalchemy
-tenacity==6.2.0           # via -r requirements.in
-toml==0.10.2              # via pytest
-urllib3==1.26.2           # via requests
-werkzeug==0.16.1          # via -r requirements.in, flask
+python-dateutil==2.8.1    # via botocore
+pytz==2020.4              # via babel, celery, flask-restful
+pyyaml==5.3.1             # via anymarkup, f8a-worker, selinon
+rainbow-logging-handler==2.2.2  # via selinon
+raven==6.10.0             # via -r requirements.in, f8a-worker
+requests-futures==1.0.0   # via -r requirements.in, f8a-worker
+requests==2.25.0          # via -r requirements.in, f8a-utils, f8a-worker, fabric8a-auth, pygithub, requests-futures
+s3transfer==0.3.3         # via boto3
+selinon[celery]==1.0.0    # via f8a-worker
+semantic-version==2.8.5   # via -r requirements.in, f8a-worker
+semver==2.13.0            # via f8a-utils
+six==1.15.0               # via anymarkup-core, click-repl, configobj, cryptography, flask-appconfig, flask-cors, flask-restful, jsonschema, packaging, python-dateutil, tenacity
+smmap==3.0.4              # via gitdb
+soupsieve==2.0.1          # via beautifulsoup4
+speaklater==1.3           # via flask-babelex
+sqlalchemy==1.3.20        # via -r requirements.in, f8a-worker, flask-sqlalchemy
+tenacity==6.2.0           # via -r requirements.in, f8a-utils, f8a-worker
+toml==0.9.4               # via anymarkup, f8a-worker, pytest
+urllib3==1.26.2           # via botocore, requests
+vine==5.0.0               # via amqp, celery
+wcwidth==0.2.5            # via prompt-toolkit
+werkzeug==0.16.1          # via -r requirements.in, f8a-worker, flask
 wrapt==1.12.1             # via deprecated
+wtforms==2.3.3            # via flask-wtf
+xmltodict==0.12.0         # via anymarkup
 zipp==3.4.0               # via importlib-metadata
+
+# The following packages are considered to be unsafe in a requirements file:
+# setuptools

--- a/setup.py
+++ b/setup.py
@@ -6,8 +6,8 @@ from setuptools import setup, find_packages
 
 
 def get_requirements():
-    """Parse all packages mentioned in the 'requirements.txt' file."""
-    with open('requirements.txt') as fd:
+    """Parse all packages mentioned in the 'requirements.in' file."""
+    with open('requirements.in') as fd:
         lines = fd.read().splitlines()
         reqs, dep_links = [], []
         for line in lines:

--- a/setup.py
+++ b/setup.py
@@ -6,8 +6,8 @@ from setuptools import setup, find_packages
 
 
 def get_requirements():
-    """Parse all packages mentioned in the 'requirements.in' file."""
-    with open('requirements.in') as fd:
+    """Parse all packages mentioned in the 'requirements.txt' file."""
+    with open('requirements.txt') as fd:
         lines = fd.read().splitlines()
         reqs, dep_links = [], []
         for line in lines:

--- a/tests/api/test_api_v2.py
+++ b/tests/api/test_api_v2.py
@@ -259,8 +259,8 @@ class TestCAPostApi(unittest.TestCase):
         response = self.client.post(
             api_route_for('/component-analyses'), data=json.dumps(payload), headers=accept_json)
         self.assertEqual(response.status_code, 400)
-        self.assertDictEqual(
-            response.json, {'error': '400 Bad Request: Ecosystem None is not supported for this request'})
+        self.assertDictEqual(response.json, 
+        {'error': '400 Bad Request: Ecosystem None is not supported for this request'})
 
 
 @pytest.mark.usefixtures('client_class')

--- a/tests/api/test_api_v2.py
+++ b/tests/api/test_api_v2.py
@@ -259,7 +259,8 @@ class TestCAPostApi(unittest.TestCase):
         response = self.client.post(
             api_route_for('/component-analyses'), data=json.dumps(payload), headers=accept_json)
         self.assertEqual(response.status_code, 400)
-        self.assertDictEqual(response.json, {'error': '400 Bad Request: Ecosystem None is not supported for this request'})
+        self.assertDictEqual(
+            response.json, {'error': '400 Bad Request: Ecosystem None is not supported for this request'})
 
 
 @pytest.mark.usefixtures('client_class')

--- a/tests/api/test_api_v2.py
+++ b/tests/api/test_api_v2.py
@@ -259,8 +259,9 @@ class TestCAPostApi(unittest.TestCase):
         response = self.client.post(
             api_route_for('/component-analyses'), data=json.dumps(payload), headers=accept_json)
         self.assertEqual(response.status_code, 400)
-        self.assertDictEqual(response.json, 
-        {'error': '400 Bad Request: Ecosystem None is not supported for this request'})
+        self.assertDictEqual(
+            response.json,
+            {'error': '400 Bad Request: Ecosystem None is not supported for this request'})
 
 
 @pytest.mark.usefixtures('client_class')

--- a/tests/api/test_api_v2.py
+++ b/tests/api/test_api_v2.py
@@ -259,7 +259,7 @@ class TestCAPostApi(unittest.TestCase):
         response = self.client.post(
             api_route_for('/component-analyses'), data=json.dumps(payload), headers=accept_json)
         self.assertEqual(response.status_code, 400)
-        self.assertDictEqual(response.json, {'error': '400: Bad Request'})
+        self.assertDictEqual(response.json, {'error': '400 Bad Request: Ecosystem None is not supported for this request'})
 
 
 @pytest.mark.usefixtures('client_class')

--- a/tests/requirements.in
+++ b/tests/requirements.in
@@ -1,4 +1,5 @@
 pytest
+pytest-flask
 pytest-cov
 radon
 -r ../requirements.in

--- a/tests/requirements.in
+++ b/tests/requirements.in
@@ -1,12 +1,4 @@
-flexmock
-freezegun
-pytest >= 3 # Needed for compatibility with celery 4.x fixtures
-pytest-flask
+pytest
 pytest-cov
-requests
-jsonschema
-pylint
-semantic_version
-pydantic
-tenacity
+radon
 -r ../requirements.in

--- a/tests/requirements.in
+++ b/tests/requirements.in
@@ -1,11 +1,7 @@
-flexmock
-freezegun
-pytest >= 3 # Needed for compatibility with celery 4.x fixtures
-pytest-flask
-pytest-cov
-requests
-jsonschema
-pylint
+pytest
 semantic_version
+Flask
+SQLAlchemy
+lxml
+Werkzeug
 pydantic
-tenacity

--- a/tests/requirements.in
+++ b/tests/requirements.in
@@ -1,7 +1,11 @@
-pytest
+flexmock
+freezegun
+pytest >= 3 # Needed for compatibility with celery 4.x fixtures
+pytest-flask
+pytest-cov
+requests
+jsonschema
+pylint
 semantic_version
-Flask
-SQLAlchemy
-lxml
-Werkzeug
 pydantic
+tenacity

--- a/tests/requirements.in
+++ b/tests/requirements.in
@@ -9,3 +9,4 @@ pylint
 semantic_version
 pydantic
 tenacity
+-r ../requirements.in

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -44,7 +44,7 @@ flask-restful==0.3.8      # via -r ../requirements.in
 flask-security==3.0.0     # via fabric8a-auth
 flask-sqlalchemy==2.4.4   # via -r ../requirements.in
 flask-wtf==0.14.3         # via flask-security
-flask==0.12.5             # via -r ../requirements.in, fabric8a-auth, flask-appconfig, flask-babelex, flask-cache, flask-cors, flask-login, flask-mail, flask-principal, flask-restful, flask-security, flask-sqlalchemy, flask-wtf
+flask==0.12.5             # via -r ../requirements.in, fabric8a-auth, flask-appconfig, flask-babelex, flask-cache, flask-cors, flask-login, flask-mail, flask-principal, flask-restful, flask-security, flask-sqlalchemy, flask-wtf, pytest-flask
 future==0.18.2            # via radon
 git2json==0.2.3           # via f8a-worker
 gitdb==4.0.5              # via gitpython
@@ -69,6 +69,7 @@ packaging==20.4           # via pytest
 passlib==1.7.4            # via flask-security
 pluggy==0.13.1            # via pytest
 prompt-toolkit==3.0.8     # via click-repl
+psycopg2-binary==2.8.6    # via -r ../requirements.in
 py-lru-cache==0.1.4       # via -r ../requirements.in
 py==1.9.0                 # via pytest
 pycparser==2.20           # via cffi
@@ -78,7 +79,8 @@ pyjwt==1.7.1              # via fabric8a-auth, pygithub
 pyparsing==2.4.7          # via packaging
 pyrsistent==0.17.3        # via jsonschema
 pytest-cov==2.10.1        # via -r requirements.in
-pytest==6.1.2             # via -r requirements.in, pytest-cov
+pytest-flask==1.1.0       # via -r requirements.in
+pytest==6.1.2             # via -r requirements.in, pytest-cov, pytest-flask
 python-dateutil==2.8.1    # via botocore
 pytz==2020.4              # via babel, celery, flask-restful
 pyyaml==5.3.1             # via anymarkup, f8a-worker, selinon
@@ -101,7 +103,7 @@ toml==0.9.4               # via anymarkup, f8a-worker, pytest
 urllib3==1.26.2           # via botocore, requests
 vine==5.0.0               # via amqp, celery
 wcwidth==0.2.5            # via prompt-toolkit
-werkzeug==0.16.1          # via -r ../requirements.in, f8a-worker, flask
+werkzeug==0.16.1          # via -r ../requirements.in, f8a-worker, flask, pytest-flask
 wrapt==1.12.1             # via deprecated
 wtforms==2.3.3            # via flask-wtf
 xmltodict==0.12.0         # via anymarkup

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -30,10 +30,10 @@ configobj==5.0.6          # via anymarkup
 coverage==5.3             # via pytest-cov
 cryptography==3.2.1       # via f8a-utils, fabric8a-auth
 deprecated==1.2.10        # via pygithub
-git+https://github.com/fabric8-analytics/fabric8-analytics-worker.git@066c2f6#egg=F8A_WORKER_VERSION  # via -r ../requirements.in
-git+https://github.com/fabric8-analytics/fabric8-analytics-utils.git@5a5ce60#egg=F8A_UTILS  # via -r ../requirements.in, f8a-worker
-git+https://github.com/fabric8-analytics/fabric8-analytics-version-comparator.git@8a57ac7#egg=f8a_version_comparator  # via -r ../requirements.in, f8a-utils
-git+https://github.com/fabric8-analytics/fabric8-analytics-auth.git@5ff9438#egg=F8A_AUTH_VERSION  # via -r ../requirements.in
+git+https://github.com/fabric8-analytics/fabric8-analytics-worker.git@066c2f6#egg=f8a_worker  # via -r ../requirements.in
+git+https://github.com/fabric8-analytics/fabric8-analytics-utils.git@5a5ce60#egg=f8a_utils  # via -r ../requirements.in, f8a-worker
+git+https://github.com/fabric8-analytics/fabric8-analytics-version-comparator.git@8a57ac7#egg=f8a_version_comparator  # via f8a-utils
+git+https://github.com/fabric8-analytics/fabric8-analytics-auth.git@5ff9438#egg=fabric8a_auth  # via -r ../requirements.in
 flask-appconfig==0.11.1   # via -r ../requirements.in
 flask-babelex==0.9.4      # via flask-security
 flask-cache==0.13.1       # via -r ../requirements.in
@@ -65,7 +65,7 @@ jsonschema==3.2.0         # via -r requirements.in, f8a-worker, selinon
 kombu==5.0.2              # via celery
 lazy-object-proxy==1.4.3  # via astroid
 logutils==0.3.5           # via rainbow-logging-handler
-lxml==4.6.1               # via -r ../requirements.in, f8a-utils, f8a-worker
+lxml==4.6.1               # via f8a-utils, f8a-worker
 markupsafe==1.1.1         # via jinja2, wtforms
 mccabe==0.6.1             # via pylint
 mod-wsgi==4.7.1           # via -r ../requirements.in
@@ -85,7 +85,7 @@ pyparsing==2.4.7          # via packaging
 pyrsistent==0.17.3        # via jsonschema
 pytest-cov==2.10.1        # via -r requirements.in
 pytest-flask==1.1.0       # via -r requirements.in
-pytest==6.1.2             # via -r ../requirements.in, -r requirements.in, pytest-cov, pytest-flask
+pytest==6.1.2             # via -r requirements.in, pytest-cov, pytest-flask
 python-dateutil==2.8.1    # via botocore, freezegun
 pytz==2020.4              # via babel, celery, flask-restful
 pyyaml==5.3.1             # via anymarkup, f8a-worker, selinon
@@ -101,14 +101,14 @@ six==1.15.0               # via anymarkup-core, astroid, click-repl, configobj, 
 smmap==3.0.4              # via gitdb
 soupsieve==2.0.1          # via beautifulsoup4
 speaklater==1.3           # via flask-babelex
-sqlalchemy==1.3.20        # via -r ../requirements.in, f8a-worker, flask-sqlalchemy
+sqlalchemy==1.3.20        # via f8a-worker, flask-sqlalchemy
 tenacity==6.2.0           # via -r ../requirements.in, -r requirements.in, f8a-utils, f8a-worker
 toml==0.9.4               # via anymarkup, f8a-worker, pylint, pytest
 typed-ast==1.4.1          # via astroid
 urllib3==1.26.2           # via botocore, requests
 vine==5.0.0               # via amqp, celery
 wcwidth==0.2.5            # via prompt-toolkit
-werkzeug==0.16.1          # via -r ../requirements.in, f8a-worker, flask, pytest-flask
+werkzeug==0.16.1          # via f8a-worker, flask, pytest-flask
 wrapt==1.12.1             # via astroid, deprecated
 wtforms==2.3.3            # via flask-wtf
 xmltodict==0.12.0         # via anymarkup

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -4,24 +4,46 @@
 #
 #    pip-compile --output-file=requirements.txt requirements.in
 #
-attrs==20.3.0             # via pytest
+astroid==2.4.2            # via pylint
+attrs==20.3.0             # via jsonschema, pytest
+certifi==2020.11.8        # via requests
+chardet==3.0.4            # via requests
 click==7.1.2              # via flask
-flask==1.1.2              # via -r requirements.in
-importlib-metadata==2.0.0  # via pluggy, pytest
+coverage==5.3             # via pytest-cov
+flask==1.1.2              # via pytest-flask
+flexmock==0.10.4          # via -r requirements.in
+freezegun==1.0.0          # via -r requirements.in
+idna==2.10                # via requests
+importlib-metadata==2.0.0  # via jsonschema, pluggy, pytest
 iniconfig==1.1.1          # via pytest
+isort==5.6.4              # via pylint
 itsdangerous==1.1.0       # via flask
 jinja2==2.11.2            # via flask
-lxml==4.6.1               # via -r requirements.in
+jsonschema==3.2.0         # via -r requirements.in
+lazy-object-proxy==1.4.3  # via astroid
 markupsafe==1.1.1         # via jinja2
+mccabe==0.6.1             # via pylint
 packaging==20.4           # via pytest
 pluggy==0.13.1            # via pytest
 py==1.9.0                 # via pytest
 pydantic==1.7.2           # via -r requirements.in
+pylint==2.6.0             # via -r requirements.in
 pyparsing==2.4.7          # via packaging
-pytest==6.1.2             # via -r requirements.in
+pyrsistent==0.17.3        # via jsonschema
+pytest-cov==2.10.1        # via -r requirements.in
+pytest-flask==1.1.0       # via -r requirements.in
+pytest==6.1.2             # via -r requirements.in, pytest-cov, pytest-flask
+python-dateutil==2.8.1    # via freezegun
+requests==2.25.0          # via -r requirements.in
 semantic-version==2.8.5   # via -r requirements.in
-six==1.15.0               # via packaging
-sqlalchemy==1.3.20        # via -r requirements.in
-toml==0.10.2              # via pytest
-werkzeug==1.0.1           # via -r requirements.in, flask
+six==1.15.0               # via astroid, jsonschema, packaging, python-dateutil, tenacity
+tenacity==6.2.0           # via -r requirements.in
+toml==0.10.2              # via pylint, pytest
+typed-ast==1.4.1          # via astroid
+urllib3==1.26.2           # via requests
+werkzeug==1.0.1           # via flask, pytest-flask
+wrapt==1.12.1             # via astroid
 zipp==3.4.0               # via importlib-metadata
+
+# The following packages are considered to be unsafe in a requirements file:
+# setuptools

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -4,45 +4,114 @@
 #
 #    pip-compile --output-file=requirements.txt requirements.in
 #
+amqp==5.0.2               # via kombu
+aniso8601==8.0.0          # via flask-restful
+anymarkup-core==0.8.1     # via anymarkup
+anymarkup==0.8.1          # via f8a-worker
 astroid==2.4.2            # via pylint
 attrs==20.3.0             # via jsonschema, pytest
+babel==2.9.0              # via flask-babelex
+beautifulsoup4==4.9.3     # via bs4, f8a-worker
+billiard==3.6.3.0         # via celery
+blinker==1.4              # via -r ../requirements.in, flask-mail, flask-principal
+boto3==1.16.25            # via f8a-worker
+botocore==1.19.25         # via boto3, f8a-worker, s3transfer
+bs4==0.0.1                # via f8a-utils
+celery==5.0.2             # via selinon
 certifi==2020.11.8        # via requests
+cffi==1.14.4              # via cryptography
 chardet==3.0.4            # via requests
-click==7.1.2              # via flask
+click-didyoumean==0.0.3   # via celery
+click-repl==0.1.6         # via celery
+click==7.1.2              # via anymarkup, celery, click-didyoumean, click-repl, flask, flask-appconfig, selinon
+codegen==1.0              # via selinon
+colorama==0.4.4           # via rainbow-logging-handler
+configobj==5.0.6          # via anymarkup
 coverage==5.3             # via pytest-cov
-flask==1.1.2              # via pytest-flask
+cryptography==3.2.1       # via f8a-utils, fabric8a-auth
+deprecated==1.2.10        # via pygithub
+git+https://github.com/fabric8-analytics/fabric8-analytics-worker.git@066c2f6#egg=F8A_WORKER_VERSION  # via -r ../requirements.in
+git+https://github.com/fabric8-analytics/fabric8-analytics-utils.git@5a5ce60#egg=F8A_UTILS  # via -r ../requirements.in, f8a-worker
+git+https://github.com/fabric8-analytics/fabric8-analytics-version-comparator.git@8a57ac7#egg=f8a_version_comparator  # via -r ../requirements.in, f8a-utils
+git+https://github.com/fabric8-analytics/fabric8-analytics-auth.git@5ff9438#egg=F8A_AUTH_VERSION  # via -r ../requirements.in
+flask-appconfig==0.11.1   # via -r ../requirements.in
+flask-babelex==0.9.4      # via flask-security
+flask-cache==0.13.1       # via -r ../requirements.in
+flask-cors==3.0.9         # via -r ../requirements.in
+flask-login==0.5.0        # via flask-security
+flask-mail==0.9.1         # via flask-security
+flask-principal==0.4.0    # via flask-security
+flask-restful==0.3.8      # via -r ../requirements.in
+flask-security==3.0.0     # via fabric8a-auth
+flask-sqlalchemy==2.4.4   # via -r ../requirements.in
+flask-wtf==0.14.3         # via flask-security
+flask==0.12.5             # via -r ../requirements.in, fabric8a-auth, flask-appconfig, flask-babelex, flask-cache, flask-cors, flask-login, flask-mail, flask-principal, flask-restful, flask-security, flask-sqlalchemy, flask-wtf, pytest-flask
 flexmock==0.10.4          # via -r requirements.in
 freezegun==1.0.0          # via -r requirements.in
+git2json==0.2.3           # via f8a-worker
+gitdb==4.0.5              # via gitpython
+gitpython==3.1.11         # via f8a-worker
+graphviz==0.15            # via selinon
 idna==2.10                # via requests
-importlib-metadata==2.0.0  # via jsonschema, pluggy, pytest
+importlib-metadata==2.0.0  # via jsonschema, kombu, pluggy, pytest
 iniconfig==1.1.1          # via pytest
 isort==5.6.4              # via pylint
-itsdangerous==1.1.0       # via flask
-jinja2==2.11.2            # via flask
-jsonschema==3.2.0         # via -r requirements.in
+itsdangerous==1.1.0       # via flask, flask-security, flask-wtf
+jinja2==2.11.2            # via flask, flask-babelex
+jmespath==0.10.0          # via boto3, botocore
+jsl==0.2.4                # via f8a-worker
+json5==0.9.5              # via anymarkup
+jsonschema==3.2.0         # via -r requirements.in, f8a-worker, selinon
+kombu==5.0.2              # via celery
 lazy-object-proxy==1.4.3  # via astroid
-markupsafe==1.1.1         # via jinja2
+logutils==0.3.5           # via rainbow-logging-handler
+lxml==4.6.1               # via -r ../requirements.in, f8a-utils, f8a-worker
+markupsafe==1.1.1         # via jinja2, wtforms
 mccabe==0.6.1             # via pylint
+mod-wsgi==4.7.1           # via -r ../requirements.in
 packaging==20.4           # via pytest
+passlib==1.7.4            # via flask-security
 pluggy==0.13.1            # via pytest
+prompt-toolkit==3.0.8     # via click-repl
+psycopg2-binary==2.8.6    # via -r ../requirements.in
+py-lru-cache==0.1.4       # via -r ../requirements.in
 py==1.9.0                 # via pytest
-pydantic==1.7.2           # via -r requirements.in
+pycparser==2.20           # via cffi
+pydantic==1.7.2           # via -r ../requirements.in, -r requirements.in
+pygithub==1.53            # via -r ../requirements.in
+pyjwt==1.7.1              # via fabric8a-auth, pygithub
 pylint==2.6.0             # via -r requirements.in
 pyparsing==2.4.7          # via packaging
 pyrsistent==0.17.3        # via jsonschema
 pytest-cov==2.10.1        # via -r requirements.in
 pytest-flask==1.1.0       # via -r requirements.in
-pytest==6.1.2             # via -r requirements.in, pytest-cov, pytest-flask
-python-dateutil==2.8.1    # via freezegun
-requests==2.25.0          # via -r requirements.in
-semantic-version==2.8.5   # via -r requirements.in
-six==1.15.0               # via astroid, jsonschema, packaging, python-dateutil, tenacity
-tenacity==6.2.0           # via -r requirements.in
-toml==0.10.2              # via pylint, pytest
+pytest==6.1.2             # via -r ../requirements.in, -r requirements.in, pytest-cov, pytest-flask
+python-dateutil==2.8.1    # via botocore, freezegun
+pytz==2020.4              # via babel, celery, flask-restful
+pyyaml==5.3.1             # via anymarkup, f8a-worker, selinon
+rainbow-logging-handler==2.2.2  # via selinon
+raven==6.10.0             # via -r ../requirements.in, f8a-worker
+requests-futures==1.0.0   # via -r ../requirements.in, f8a-worker
+requests==2.25.0          # via -r ../requirements.in, -r requirements.in, f8a-utils, f8a-worker, fabric8a-auth, pygithub, requests-futures
+s3transfer==0.3.3         # via boto3
+selinon[celery]==1.0.0    # via f8a-worker
+semantic-version==2.8.5   # via -r ../requirements.in, -r requirements.in, f8a-worker
+semver==2.13.0            # via f8a-utils
+six==1.15.0               # via anymarkup-core, astroid, click-repl, configobj, cryptography, flask-appconfig, flask-cors, flask-restful, jsonschema, packaging, python-dateutil, tenacity
+smmap==3.0.4              # via gitdb
+soupsieve==2.0.1          # via beautifulsoup4
+speaklater==1.3           # via flask-babelex
+sqlalchemy==1.3.20        # via -r ../requirements.in, f8a-worker, flask-sqlalchemy
+tenacity==6.2.0           # via -r ../requirements.in, -r requirements.in, f8a-utils, f8a-worker
+toml==0.9.4               # via anymarkup, f8a-worker, pylint, pytest
 typed-ast==1.4.1          # via astroid
-urllib3==1.26.2           # via requests
-werkzeug==1.0.1           # via flask, pytest-flask
-wrapt==1.12.1             # via astroid
+urllib3==1.26.2           # via botocore, requests
+vine==5.0.0               # via amqp, celery
+wcwidth==0.2.5            # via prompt-toolkit
+werkzeug==0.16.1          # via -r ../requirements.in, f8a-worker, flask, pytest-flask
+wrapt==1.12.1             # via astroid, deprecated
+wtforms==2.3.3            # via flask-wtf
+xmltodict==0.12.0         # via anymarkup
 zipp==3.4.0               # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -7,12 +7,12 @@
 astroid==1.4.8            # via pylint
 click==6.6                # via flask
 coverage==4.4.2           # via pytest-cov
-flask==0.11.1             # via pytest-flask
+flask==1.1.2             # via pytest-flask
 flexmock==0.10.2          # via -r requirements.in
 freezegun==0.3.7          # via -r requirements.in
 isort==4.2.5              # via pylint
 itsdangerous==0.24        # via flask
-jinja2==2.8               # via flask
+jinja2==2.11.2               # via flask
 jsonschema==2.5.1         # via -r requirements.in
 lazy-object-proxy==1.2.2  # via astroid
 markupsafe==0.23          # via jinja2
@@ -24,9 +24,9 @@ pytest-cov==2.5.1         # via -r requirements.in
 pytest-flask==0.10.0      # via -r requirements.in
 pytest==3.0.3             # via -r requirements.in, pytest-cov, pytest-flask
 python-dateutil==2.5.3    # via freezegun
-requests==2.11.1          # via -r requirements.in
+requests==2.24.0          # via -r requirements.in
 semantic-version==2.8.4   # via -r requirements.in
 six==1.10.0               # via astroid, freezegun, pylint, python-dateutil, tenacity
 tenacity==6.2.0           # via -r requirements.in
-werkzeug==0.11.11         # via flask, pytest-flask
+werkzeug==1.0.1         # via flask, pytest-flask
 wrapt==1.10.8             # via astroid

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -4,29 +4,24 @@
 #
 #    pip-compile --output-file=requirements.txt requirements.in
 #
-astroid==1.4.8            # via pylint
-click==6.6                # via flask
-coverage==4.4.2           # via pytest-cov
-flask==1.1.2             # via pytest-flask
-flexmock==0.10.2          # via -r requirements.in
-freezegun==0.3.7          # via -r requirements.in
-isort==4.2.5              # via pylint
-itsdangerous==0.24        # via flask
-jinja2==2.11.2               # via flask
-jsonschema==2.5.1         # via -r requirements.in
-lazy-object-proxy==1.2.2  # via astroid
-markupsafe==0.23          # via jinja2
-mccabe==0.5.2             # via pylint
-py==1.4.31                # via pytest
-pydantic==1.5.1           # via -r requirements.in
-pylint==1.6.4             # via -r requirements.in
-pytest-cov==2.5.1         # via -r requirements.in
-pytest-flask==0.10.0      # via -r requirements.in
-pytest==3.0.3             # via -r requirements.in, pytest-cov, pytest-flask
-python-dateutil==2.5.3    # via freezegun
-requests==2.24.0          # via -r requirements.in
-semantic-version==2.8.4   # via -r requirements.in
-six==1.10.0               # via astroid, freezegun, pylint, python-dateutil, tenacity
-tenacity==6.2.0           # via -r requirements.in
-werkzeug==1.0.1         # via flask, pytest-flask
-wrapt==1.10.8             # via astroid
+attrs==20.3.0             # via pytest
+click==7.1.2              # via flask
+flask==1.1.2              # via -r requirements.in
+importlib-metadata==2.0.0  # via pluggy, pytest
+iniconfig==1.1.1          # via pytest
+itsdangerous==1.1.0       # via flask
+jinja2==2.11.2            # via flask
+lxml==4.6.1               # via -r requirements.in
+markupsafe==1.1.1         # via jinja2
+packaging==20.4           # via pytest
+pluggy==0.13.1            # via pytest
+py==1.9.0                 # via pytest
+pydantic==1.7.2           # via -r requirements.in
+pyparsing==2.4.7          # via packaging
+pytest==6.1.2             # via -r requirements.in
+semantic-version==2.8.5   # via -r requirements.in
+six==1.15.0               # via packaging
+sqlalchemy==1.3.20        # via -r requirements.in
+toml==0.10.2              # via pytest
+werkzeug==1.0.1           # via -r requirements.in, flask
+zipp==3.4.0               # via importlib-metadata

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -8,14 +8,13 @@ amqp==5.0.2               # via kombu
 aniso8601==8.0.0          # via flask-restful
 anymarkup-core==0.8.1     # via anymarkup
 anymarkup==0.8.1          # via f8a-worker
-astroid==2.4.2            # via pylint
 attrs==20.3.0             # via jsonschema, pytest
 babel==2.9.0              # via flask-babelex
 beautifulsoup4==4.9.3     # via bs4, f8a-worker
 billiard==3.6.3.0         # via celery
-blinker==1.4              # via -r ../requirements.in, flask-mail, flask-principal
+blinker==1.4              # via flask-mail, flask-principal
 boto3==1.16.25            # via f8a-worker
-botocore==1.19.25         # via boto3, f8a-worker, s3transfer
+botocore==1.19.25         # via -r ../requirements.in, boto3, f8a-worker, s3transfer
 bs4==0.0.1                # via f8a-utils
 celery==5.0.2             # via selinon
 certifi==2020.11.8        # via requests
@@ -25,14 +24,14 @@ click-didyoumean==0.0.3   # via celery
 click-repl==0.1.6         # via celery
 click==7.1.2              # via anymarkup, celery, click-didyoumean, click-repl, flask, flask-appconfig, selinon
 codegen==1.0              # via selinon
-colorama==0.4.4           # via rainbow-logging-handler
+colorama==0.4.4           # via radon, rainbow-logging-handler
 configobj==5.0.6          # via anymarkup
 coverage==5.3             # via pytest-cov
 cryptography==3.2.1       # via f8a-utils, fabric8a-auth
 deprecated==1.2.10        # via pygithub
-git+https://github.com/fabric8-analytics/fabric8-analytics-worker.git@066c2f6#egg=f8a_worker  # via -r ../requirements.in
 git+https://github.com/fabric8-analytics/fabric8-analytics-utils.git@5a5ce60#egg=f8a_utils  # via -r ../requirements.in, f8a-worker
 git+https://github.com/fabric8-analytics/fabric8-analytics-version-comparator.git@8a57ac7#egg=f8a_version_comparator  # via f8a-utils
+git+https://github.com/fabric8-analytics/fabric8-analytics-worker.git@066c2f6#egg=f8a_worker  # via -r ../requirements.in
 git+https://github.com/fabric8-analytics/fabric8-analytics-auth.git@5ff9438#egg=fabric8a_auth  # via -r ../requirements.in
 flask-appconfig==0.11.1   # via -r ../requirements.in
 flask-babelex==0.9.4      # via flask-security
@@ -45,71 +44,65 @@ flask-restful==0.3.8      # via -r ../requirements.in
 flask-security==3.0.0     # via fabric8a-auth
 flask-sqlalchemy==2.4.4   # via -r ../requirements.in
 flask-wtf==0.14.3         # via flask-security
-flask==0.12.5             # via -r ../requirements.in, fabric8a-auth, flask-appconfig, flask-babelex, flask-cache, flask-cors, flask-login, flask-mail, flask-principal, flask-restful, flask-security, flask-sqlalchemy, flask-wtf, pytest-flask
-flexmock==0.10.4          # via -r requirements.in
-freezegun==1.0.0          # via -r requirements.in
+flask==0.12.5             # via -r ../requirements.in, fabric8a-auth, flask-appconfig, flask-babelex, flask-cache, flask-cors, flask-login, flask-mail, flask-principal, flask-restful, flask-security, flask-sqlalchemy, flask-wtf
+future==0.18.2            # via radon
 git2json==0.2.3           # via f8a-worker
 gitdb==4.0.5              # via gitpython
-gitpython==3.1.11         # via f8a-worker
+gitpython==3.1.11         # via -r ../requirements.in, f8a-worker
 graphviz==0.15            # via selinon
 idna==2.10                # via requests
-importlib-metadata==2.0.0  # via jsonschema, kombu, pluggy, pytest
+importlib-metadata==3.1.0  # via jsonschema, kombu, pluggy, pytest
 iniconfig==1.1.1          # via pytest
-isort==5.6.4              # via pylint
 itsdangerous==1.1.0       # via flask, flask-security, flask-wtf
 jinja2==2.11.2            # via flask, flask-babelex
 jmespath==0.10.0          # via boto3, botocore
 jsl==0.2.4                # via f8a-worker
 json5==0.9.5              # via anymarkup
-jsonschema==3.2.0         # via -r requirements.in, f8a-worker, selinon
+jsonschema==3.2.0         # via f8a-worker, selinon
 kombu==5.0.2              # via celery
-lazy-object-proxy==1.4.3  # via astroid
 logutils==0.3.5           # via rainbow-logging-handler
-lxml==4.6.1               # via f8a-utils, f8a-worker
+lxml==4.6.1               # via -r ../requirements.in, f8a-utils, f8a-worker
+mando==0.6.4              # via radon
 markupsafe==1.1.1         # via jinja2, wtforms
-mccabe==0.6.1             # via pylint
 mod-wsgi==4.7.1           # via -r ../requirements.in
 packaging==20.4           # via pytest
 passlib==1.7.4            # via flask-security
 pluggy==0.13.1            # via pytest
 prompt-toolkit==3.0.8     # via click-repl
-psycopg2-binary==2.8.6    # via -r ../requirements.in
 py-lru-cache==0.1.4       # via -r ../requirements.in
 py==1.9.0                 # via pytest
 pycparser==2.20           # via cffi
-pydantic==1.7.2           # via -r ../requirements.in, -r requirements.in
+pydantic==1.7.2           # via -r ../requirements.in
 pygithub==1.53            # via -r ../requirements.in
 pyjwt==1.7.1              # via fabric8a-auth, pygithub
-pylint==2.6.0             # via -r requirements.in
 pyparsing==2.4.7          # via packaging
 pyrsistent==0.17.3        # via jsonschema
 pytest-cov==2.10.1        # via -r requirements.in
-pytest-flask==1.1.0       # via -r requirements.in
-pytest==6.1.2             # via -r requirements.in, pytest-cov, pytest-flask
-python-dateutil==2.8.1    # via botocore, freezegun
+pytest==6.1.2             # via -r requirements.in, pytest-cov
+python-dateutil==2.8.1    # via botocore
 pytz==2020.4              # via babel, celery, flask-restful
 pyyaml==5.3.1             # via anymarkup, f8a-worker, selinon
+radon==4.3.2              # via -r requirements.in
 rainbow-logging-handler==2.2.2  # via selinon
 raven==6.10.0             # via -r ../requirements.in, f8a-worker
 requests-futures==1.0.0   # via -r ../requirements.in, f8a-worker
-requests==2.25.0          # via -r ../requirements.in, -r requirements.in, f8a-utils, f8a-worker, fabric8a-auth, pygithub, requests-futures
+requests==2.25.0          # via -r ../requirements.in, f8a-utils, f8a-worker, fabric8a-auth, pygithub, requests-futures
 s3transfer==0.3.3         # via boto3
-selinon[celery]==1.0.0    # via f8a-worker
-semantic-version==2.8.5   # via -r ../requirements.in, -r requirements.in, f8a-worker
+selinon==1.0.0            # via -r ../requirements.in, f8a-worker
+semantic-version==2.8.5   # via -r ../requirements.in, f8a-worker
 semver==2.13.0            # via f8a-utils
-six==1.15.0               # via anymarkup-core, astroid, click-repl, configobj, cryptography, flask-appconfig, flask-cors, flask-restful, jsonschema, packaging, python-dateutil, tenacity
+six==1.15.0               # via anymarkup-core, click-repl, configobj, cryptography, flask-appconfig, flask-cors, flask-restful, jsonschema, mando, packaging, python-dateutil, tenacity
 smmap==3.0.4              # via gitdb
 soupsieve==2.0.1          # via beautifulsoup4
 speaklater==1.3           # via flask-babelex
-sqlalchemy==1.3.20        # via f8a-worker, flask-sqlalchemy
-tenacity==6.2.0           # via -r ../requirements.in, -r requirements.in, f8a-utils, f8a-worker
-toml==0.9.4               # via anymarkup, f8a-worker, pylint, pytest
-typed-ast==1.4.1          # via astroid
+sqlalchemy==1.3.20        # via -r ../requirements.in, f8a-worker, flask-sqlalchemy
+tenacity==6.2.0           # via -r ../requirements.in, f8a-utils, f8a-worker
+toml==0.9.4               # via anymarkup, f8a-worker, pytest
 urllib3==1.26.2           # via botocore, requests
 vine==5.0.0               # via amqp, celery
 wcwidth==0.2.5            # via prompt-toolkit
-werkzeug==0.16.1          # via f8a-worker, flask, pytest-flask
-wrapt==1.12.1             # via astroid, deprecated
+werkzeug==0.16.1          # via -r ../requirements.in, f8a-worker, flask
+wrapt==1.12.1             # via deprecated
 wtforms==2.3.3            # via flask-wtf
 xmltodict==0.12.0         # via anymarkup
 zipp==3.4.0               # via importlib-metadata


### PR DESCRIPTION
This is WIP PR which takes care of dependency unification for the api server.

Checklist ::
 - [x] Move any test specific packages from requirements.in to tests/requirements.in
 - [x] Move any direct pip installations from Dockerfile.* to requirements.in
 - [ ] Move any direct pip installations from tests/*.sh to tests/requirements.in
 - [x] Relative versioning in requirements.in & tests/requirements.in (no version pinning unless otherwise needed)
 - [x] Generate requirements.txt (not required) and tests/requirements.txt
 - [ ] (Not Applicable)Update setup.py to use requirement.in
 - [x] Cleanup unused dependencies from requirements.in and tests/requirements.in (using `pip install pipreqs`)