### PR TITLE
chore: [APPAI-1639] Modified package name to include module name and include the same in response

### DIFF
--- a/tests/data/response/ca_batch_with_n_without_vul_golang.json
+++ b/tests/data/response/ca_batch_with_n_without_vul_golang.json
@@ -8,8 +8,8 @@
     {
         "highest_severity": "medium",
         "known_security_vulnerability_count": 2,
-        "message": "code.cloudfoundry.org/gorouter/route - v0.0.0-20170410000936-a663fba25f7a has 2 known security vulnerability having medium severity. Recommendation: use version v3.0.7.",
-        "package": "code.cloudfoundry.org/gorouter/route",
+        "message": "code.cloudfoundry.org/gorouter/route@code.cloudfoundry.org/gorouter - v0.0.0-20170410000936-a663fba25f7a has 2 known security vulnerability having medium severity. Recommendation: use version v3.0.7.",
+        "package": "code.cloudfoundry.org/gorouter/route@code.cloudfoundry.org/gorouter",
         "recommended_versions": "v3.0.7",
         "registration_link": "https://app.snyk.io/login",
         "security_advisory_count": 0,


### PR DESCRIPTION
This PR synchronised the package name format between CA and SA request for golang. Package name includes module like package_name@module_name. CA response should also include package name in this format, this will help plugin to simplify their logic of consuming CA data and forming aggregated diagnostic message.

Jira Ticket :: https://issues.redhat.com/browse/APPAI-1639