### PR TITLE
chore: Remove reference to requestJson column from SA requests table

### DIFF
--- a/bayesian/api_v1.py
+++ b/bayesian/api_v1.py
@@ -929,6 +929,7 @@ class StackAnalyses(Resource):
             insert_stmt = insert(StackAnalysisRequest).values(
                 id=request_id,
                 submitTime=str(dt),
+                requestJson={'manifest': manifests},
                 dep_snapshot=deps
             )
             do_update_stmt = insert_stmt.on_conflict_do_update(

--- a/bayesian/api_v1.py
+++ b/bayesian/api_v1.py
@@ -929,7 +929,6 @@ class StackAnalyses(Resource):
             insert_stmt = insert(StackAnalysisRequest).values(
                 id=request_id,
                 submitTime=str(dt),
-                requestJson={'manifest': manifests},
                 dep_snapshot=deps
             )
             do_update_stmt = insert_stmt.on_conflict_do_update(

--- a/bayesian/utility/db_gateway.py
+++ b/bayesian/utility/db_gateway.py
@@ -237,7 +237,6 @@ class RdbAnalyses:
             insert_stmt = insert(StackAnalysisRequest).values(
                 id=self.request_id,
                 submitTime=self.submit_time,
-                requestJson={'manifest': self.manifest},
                 dep_snapshot=self.deps
             )
             do_update_stmt = insert_stmt.on_conflict_do_update(


### PR DESCRIPTION
The requestJson column has been removed from SA table as it contains duplicate data.[https://github.com/fabric8-analytics/fabric8-analytics-worker/pull/926](url).