### PR TITLE
fix: Persist uuid from SA call in `stack_analyses_request` table

### DIFF
--- a/bayesian/api/api_v2.py
+++ b/bayesian/api/api_v2.py
@@ -293,7 +293,7 @@ def stack_analyses():
     start = time.time()
     if request.method == 'GET':
         raise HTTPError(400, error="Request id missing")
-
+    
     sa_post_request = None
     try:
         # 1. Validate and build request object.

--- a/bayesian/api/api_v2.py
+++ b/bayesian/api/api_v2.py
@@ -293,7 +293,7 @@ def stack_analyses():
     start = time.time()
     if request.method == 'GET':
         raise HTTPError(400, error="Request id missing")
-    
+
     sa_post_request = None
     try:
         # 1. Validate and build request object.

--- a/bayesian/utility/db_gateway.py
+++ b/bayesian/utility/db_gateway.py
@@ -31,6 +31,7 @@ from sqlalchemy.dialects.postgresql import insert
 
 from f8a_worker.models import StackAnalysisRequest
 
+
 logger = logging.getLogger(__name__)
 gremlin_url = "http://{host}:{port}".format(
     host=os.environ.get("BAYESIAN_GREMLIN_HTTP_SERVICE_HOST", "localhost"),
@@ -217,12 +218,13 @@ class RdbAnalyses:
     Provides interfaces to save and read request post data for stack analyses v2.
     """
 
-    def __init__(self, request_id, submit_time=None, manifest=None, deps=None):
+    def __init__(self, request_id, submit_time=None, manifest=None, deps=None, user_id=None):
         """Set request id."""
         self.request_id = request_id
         self.submit_time = submit_time
         self.manifest = manifest
         self.deps = deps
+        self.user_id = user_id
 
     def get_request_data(self):
         """Read request data for given request id from RDS."""
@@ -253,13 +255,15 @@ class RdbAnalyses:
 
     def save_post_request(self):
         """Save the post request data into RDS."""
+        print(self.user_id)
         try:
             start = time.time()
             insert_stmt = insert(StackAnalysisRequest).values(
                 id=self.request_id,
                 submitTime=self.submit_time,
                 requestJson={'manifest': self.manifest},
-                dep_snapshot=self.deps
+                dep_snapshot=self.deps,
+                user_id=self.user_id
             )
             do_update_stmt = insert_stmt.on_conflict_do_update(
                 index_elements=['id'],

--- a/bayesian/utility/db_gateway.py
+++ b/bayesian/utility/db_gateway.py
@@ -217,13 +217,9 @@ class RdbAnalyses:
     Provides interfaces to save and read request post data for stack analyses v2.
     """
 
-    def __init__(self, request_id, submit_time=None, manifest=None, deps=None, user_id=None):
+    def __init__(self, request_id):
         """Set request id."""
         self.request_id = request_id
-        self.submit_time = submit_time
-        self.manifest = manifest
-        self.deps = deps
-        self.user_id = user_id
 
     def get_request_data(self):
         """Read request data for given request id from RDS."""
@@ -252,20 +248,20 @@ class RdbAnalyses:
         """Read and return recommendation data from RDS."""
         return retrieve_worker_result(rdb, self.request_id, 'recommendation_v2')
 
-    def save_post_request(self):
+    def save_post_request(self, date_str, uuid_data, deps, manifest):
         """Save the post request data into RDS."""
         try:
             start = time.time()
             insert_stmt = insert(StackAnalysisRequest).values(
                 id=self.request_id,
-                submitTime=self.submit_time,
-                requestJson={'manifest': self.manifest},
-                dep_snapshot=self.deps,
-                user_id=self.user_id
+                submitTime=date_str,
+                requestJson={'manifest': manifest},
+                dep_snapshot=deps,
+                user_id=uuid_data
             )
             do_update_stmt = insert_stmt.on_conflict_do_update(
                 index_elements=['id'],
-                set_=dict(dep_snapshot=self.deps)
+                set_=dict(dep_snapshot=deps)
             )
             rdb.session.execute(do_update_stmt)
             rdb.session.commit()

--- a/bayesian/utility/db_gateway.py
+++ b/bayesian/utility/db_gateway.py
@@ -31,7 +31,6 @@ from sqlalchemy.dialects.postgresql import insert
 
 from f8a_worker.models import StackAnalysisRequest
 
-
 logger = logging.getLogger(__name__)
 gremlin_url = "http://{host}:{port}".format(
     host=os.environ.get("BAYESIAN_GREMLIN_HTTP_SERVICE_HOST", "localhost"),
@@ -255,7 +254,6 @@ class RdbAnalyses:
 
     def save_post_request(self):
         """Save the post request data into RDS."""
-        print(self.user_id)
         try:
             start = time.time()
             insert_stmt = insert(StackAnalysisRequest).values(

--- a/bayesian/utility/v2/stack_analyses.py
+++ b/bayesian/utility/v2/stack_analyses.py
@@ -25,7 +25,6 @@ from flask import request
 from bayesian.dependency_finder import DependencyFinder
 from bayesian.utility.db_gateway import RdbAnalyses
 from bayesian.utility.v2.backbone_server import BackboneServer
-from bayesian.utility.v2.sa_models import HeaderData
 
 logger = logging.getLogger(__name__)
 
@@ -58,15 +57,14 @@ class StackAnalyses():
         self._new_request_id = str(uuid.uuid4().hex)
         date_str = str(datetime.datetime.now())
         # Fetch uuid from header
-        header_data = HeaderData(uuid=request.headers.get('uuid', None))
+        uuid_data = request.headers.get('uuid', None)
 
         # Make backbone request
         deps = self._make_backbone_request()
 
         # Finally save results in RDS and upon success return request id.
-        rdbAnalyses = RdbAnalyses(self._new_request_id, date_str,
-                                  self._manifest_file_info, deps, header_data.uuid)
-        rdbAnalyses.save_post_request()
+        rdbAnalyses = RdbAnalyses(self._new_request_id)
+        rdbAnalyses.save_post_request(date_str, uuid_data, deps, self._manifest_file_info)
         data = {
             'status': 'success',
             'submitted_at': date_str,

--- a/bayesian/utility/v2/stack_analyses.py
+++ b/bayesian/utility/v2/stack_analyses.py
@@ -21,9 +21,13 @@ import uuid
 import json
 import logging
 from flask import g
+from flask import request
+
 from bayesian.dependency_finder import DependencyFinder
 from bayesian.utility.db_gateway import RdbAnalyses
 from bayesian.utility.v2.backbone_server import BackboneServer
+from bayesian.utility.v2.sa_models import HeaderData
+
 
 logger = logging.getLogger(__name__)
 
@@ -55,13 +59,15 @@ class StackAnalyses():
         # Generate unique request id using UUID, also record timestamp in readable form
         self._new_request_id = str(uuid.uuid4().hex)
         date_str = str(datetime.datetime.now())
+        # Fetch uuid from header
+        header_data = HeaderData(uuid=request.headers.get('uuid', None))
 
         # Make backbone request
         deps = self._make_backbone_request()
 
         # Finally save results in RDS and upon success return request id.
         rdbAnalyses = RdbAnalyses(self._new_request_id, date_str,
-                                  self._manifest_file_info, deps)
+                                  self._manifest_file_info, deps, header_data.uuid)
         rdbAnalyses.save_post_request()
         data = {
             'status': 'success',

--- a/bayesian/utility/v2/stack_analyses.py
+++ b/bayesian/utility/v2/stack_analyses.py
@@ -22,6 +22,7 @@ import json
 import logging
 from flask import g
 from flask import request
+from flask import has_request_context
 from bayesian.dependency_finder import DependencyFinder
 from bayesian.utility.db_gateway import RdbAnalyses
 from bayesian.utility.v2.backbone_server import BackboneServer
@@ -57,8 +58,10 @@ class StackAnalyses():
         self._new_request_id = str(uuid.uuid4().hex)
         date_str = str(datetime.datetime.now())
         # Fetch uuid from header
-        uuid_data = request.headers.get('uuid', None)
-
+        if has_request_context():
+            uuid_data = request.headers.get('uuid', None)
+        else:
+            uuid_data = None
         # Make backbone request
         deps = self._make_backbone_request()
 

--- a/bayesian/utility/v2/stack_analyses.py
+++ b/bayesian/utility/v2/stack_analyses.py
@@ -22,12 +22,10 @@ import json
 import logging
 from flask import g
 from flask import request
-
 from bayesian.dependency_finder import DependencyFinder
 from bayesian.utility.db_gateway import RdbAnalyses
 from bayesian.utility.v2.backbone_server import BackboneServer
 from bayesian.utility.v2.sa_models import HeaderData
-
 
 logger = logging.getLogger(__name__)
 

--- a/requirements.in
+++ b/requirements.in
@@ -28,7 +28,7 @@ psycopg2-binary
 mod_wsgi!=4.5.4
 
 
-f8a_worker @ git+https://github.com/fabric8-analytics/fabric8-analytics-worker.git@066c2f6#egg=f8a_worker
+f8a_worker @ git+https://github.com/fabric8-analytics/fabric8-analytics-worker.git@b4e1fea#egg=f8a_worker
 f8a_auth @ git+https://github.com/fabric8-analytics/fabric8-analytics-auth.git@5ff9438#egg=fabric8a_auth
 f8a_utils @ git+https://github.com/fabric8-analytics/fabric8-analytics-utils.git@c9d3f47#egg=f8a_utils
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --output-file=requirements.txt requirements.in
 #
-amqp==5.0.2               # via kombu
+amqp==2.6.1               # via kombu
 aniso8601==8.0.0          # via flask-restful
 anymarkup-core==0.8.1     # via anymarkup
 anymarkup==0.8.1          # via f8a-worker
@@ -16,21 +16,19 @@ blinker==1.4              # via flask-mail, flask-principal
 boto3==1.16.25            # via f8a-worker
 botocore==1.19.25         # via -r requirements.in, boto3, f8a-worker, s3transfer
 bs4==0.0.1                # via f8a-utils
-celery==5.0.2             # via selinon
+celery==4.4.7             # via f8a-worker
 certifi==2020.11.8        # via requests
 cffi==1.14.4              # via cryptography
 chardet==3.0.4            # via requests
-click-didyoumean==0.0.3   # via celery
-click-repl==0.1.6         # via celery
-click==7.1.2              # via anymarkup, celery, click-didyoumean, click-repl, flask, flask-appconfig, selinon
+click==7.1.2              # via anymarkup, flask, flask-appconfig, selinon
 codegen==1.0              # via selinon
 colorama==0.4.4           # via rainbow-logging-handler
 configobj==5.0.6          # via anymarkup
 cryptography==3.2.1       # via f8a-utils, fabric8a-auth
 deprecated==1.2.10        # via pygithub
-git+https://github.com/fabric8-analytics/fabric8-analytics-utils.git@5a5ce60#egg=f8a_utils  # via -r requirements.in, f8a-worker
+git+https://github.com/fabric8-analytics/fabric8-analytics-utils.git@c9d3f47#egg=f8a_utils  # via -r requirements.in, f8a-worker
 git+https://github.com/fabric8-analytics/fabric8-analytics-version-comparator.git@8a57ac7#egg=f8a_version_comparator  # via f8a-utils
-git+https://github.com/fabric8-analytics/fabric8-analytics-worker.git@066c2f6#egg=f8a_worker  # via -r requirements.in
+git+https://github.com/fabric8-analytics/fabric8-analytics-worker.git@b4e1fea#egg=f8a_worker  # via -r requirements.in
 git+https://github.com/fabric8-analytics/fabric8-analytics-auth.git@5ff9438#egg=fabric8a_auth  # via -r requirements.in
 flask-appconfig==0.11.1   # via -r requirements.in
 flask-babelex==0.9.4      # via flask-security
@@ -56,13 +54,12 @@ jmespath==0.10.0          # via boto3, botocore
 jsl==0.2.4                # via f8a-worker
 json5==0.9.5              # via anymarkup
 jsonschema==3.2.0         # via f8a-worker, selinon
-kombu==5.0.2              # via celery
+kombu==4.6.11             # via celery
 logutils==0.3.5           # via rainbow-logging-handler
 lxml==4.6.1               # via -r requirements.in, f8a-utils, f8a-worker
 markupsafe==1.1.1         # via jinja2, wtforms
 mod-wsgi==4.7.1           # via -r requirements.in
 passlib==1.7.4            # via flask-security
-prompt-toolkit==3.0.8     # via click-repl
 psycopg2-binary==2.8.6    # via -r requirements.in
 py-lru-cache==0.1.4       # via -r requirements.in
 pycparser==2.20           # via cffi
@@ -81,7 +78,7 @@ s3transfer==0.3.3         # via boto3
 selinon==1.0.0            # via -r requirements.in, f8a-worker
 semantic-version==2.8.5   # via -r requirements.in, f8a-worker
 semver==2.13.0            # via f8a-utils
-six==1.15.0               # via anymarkup-core, click-repl, configobj, cryptography, flask-appconfig, flask-cors, flask-restful, jsonschema, python-dateutil, tenacity
+six==1.15.0               # via anymarkup-core, configobj, cryptography, flask-appconfig, flask-cors, flask-restful, jsonschema, python-dateutil, tenacity
 smmap==3.0.4              # via gitdb
 soupsieve==2.0.1          # via beautifulsoup4
 speaklater==1.3           # via flask-babelex
@@ -89,8 +86,7 @@ sqlalchemy==1.3.20        # via -r requirements.in, f8a-worker, flask-sqlalchemy
 tenacity==6.2.0           # via -r requirements.in, f8a-utils, f8a-worker
 toml==0.9.4               # via anymarkup, f8a-worker
 urllib3==1.26.2           # via botocore, requests
-vine==5.0.0               # via amqp, celery
-wcwidth==0.2.5            # via prompt-toolkit
+vine==1.3.0               # via amqp, celery
 werkzeug==0.16.1          # via -r requirements.in, f8a-worker, flask
 wrapt==1.12.1             # via deprecated
 wtforms==2.3.3            # via flask-wtf

--- a/tests/utility/test_db_gateway.py
+++ b/tests/utility/test_db_gateway.py
@@ -263,14 +263,14 @@ class TestRdbAnalyses(unittest.TestCase):
            side_effect=SQLAlchemyError('Mock exception'))
     def test_save_post_request_error(self, _execute):
         """Test error save request that raises exception."""
-        rdbAnalyses = RdbAnalyses('dummy_request_id', '', {}, {})
+        rdbAnalyses = RdbAnalyses('dummy_request_id')
         with pytest.raises(Exception) as exception:
-            rdbAnalyses.save_post_request()
+            rdbAnalyses.save_post_request('', '', {}, {})
         self.assertIs(exception.type, RDBSaveException)
 
     @patch('bayesian.utility.db_gateway.rdb.session.execute', return_value=0)
     @patch('bayesian.utility.db_gateway.rdb.session.commit', return_value=0)
     def test_save_post_request_success(self, _commit, _execute):
         """Test success save request."""
-        rdbAnalyses = RdbAnalyses('dummy_request_id', '', {}, {})
-        self.assertEqual(rdbAnalyses.save_post_request(), None)
+        rdbAnalyses = RdbAnalyses('dummy_request_id')
+        self.assertEqual(rdbAnalyses.save_post_request('', '', {}, {}), None)


### PR DESCRIPTION
This pr makes chnages in the api server so it can store the uuid from sa calls into the newly created user_id column in stack_analyses_request table.