### PR TITLE
fix: build infra issue after migrating to ubi

### DIFF
--- a/cico_setup.sh
+++ b/cico_setup.sh
@@ -21,7 +21,10 @@ load_jenkins_vars() {
 
 prep() {
     yum -y update
-    yum -y install docker git openssl-devel gcc
+    yum -y install docker git openssl-devel gcc subscription-manager-rhsm-certificates
+    # fix based on https://github.com/minishift/minishift-centos-iso/pull/255
+    # to enable ubi builds
+    touch /etc/rhsm/ca/redhat-uep.pem
     systemctl start docker
 }
 


### PR DESCRIPTION
This fix is based on https://github.com/minishift/minishift-centos-iso/pull/255

https://ci.centos.org/job/devtools-fabric8-analytics-server-f8a-build-master/430/console
```
Trying to pull repository registry.access.redhat.com/ubi8/ubi-minimal ... 
open /etc/docker/certs.d/registry.access.redhat.com/redhat-ca.crt: no such file or directory
make: *** [docker-build] Error 1
```