### PR TITLE
fix: remove unused test image make targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,5 @@
 REGISTRY ?= quay.io
 DEFAULT_TAG = latest
-TESTS_IMAGE=server-tests
 
 DOCKERFILE := Dockerfile
 ifeq ($(TARGET),rhel)
@@ -9,28 +8,22 @@ else
 	REPOSITORY ?= openshiftio/bayesian-bayesian-api
 endif
 
-.PHONY: all docker-build fast-docker-build test get-image-name get-image-repository docker-build-tests fast-docker-build-tests
+.PHONY: all docker-build fast-docker-build test get-image-name get-image-repository
 
 all: fast-docker-build
 
-docker-build:
+hack/coreapi-release:
 	git show -s --format="COMMITTED_AT=%ai%nCOMMIT_HASH=%h%n" HEAD > hack/coreapi-release
+
+docker-build: hack/coreapi-release
 	docker build --no-cache -t $(REGISTRY)/$(REPOSITORY):$(DEFAULT_TAG) -f $(DOCKERFILE) .
-	docker tag $(REGISTRY)/$(REPOSITORY):$(DEFAULT_TAG) $(TESTS_IMAGE):$(DEFAULT_TAG)
 	docker tag $(REGISTRY)/$(REPOSITORY):$(DEFAULT_TAG) bayesian-api
 
-docker-build-tests: docker-build
-	docker build --no-cache -t $(TESTS_IMAGE) -f Dockerfile.tests .
-
-fast-docker-build:
+fast-docker-build: hack/coreapi-release
 	docker build -t $(REGISTRY)/$(REPOSITORY):$(DEFAULT_TAG) -f $(DOCKERFILE) .
-	docker tag $(REGISTRY)/$(REPOSITORY):$(DEFAULT_TAG) $(TESTS_IMAGE):$(DEFAULT_TAG)
 	docker tag $(REGISTRY)/$(REPOSITORY):$(DEFAULT_TAG) bayesian-api
 
-fast-docker-build-tests:
-	docker build -t $(TESTS_IMAGE) -f Dockerfile.tests .
-
-test: fast-docker-build-tests
+test: fast-docker-build
 	./runtest.sh
 
 get-image-name:

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 REGISTRY ?= quay.io
 DEFAULT_TAG = latest
+IMAGE_NAME ?= bayesian-api
 
 DOCKERFILE := Dockerfile
 ifeq ($(TARGET),rhel)
@@ -17,11 +18,11 @@ hack/coreapi-release:
 
 docker-build: hack/coreapi-release
 	docker build --no-cache -t $(REGISTRY)/$(REPOSITORY):$(DEFAULT_TAG) -f $(DOCKERFILE) .
-	docker tag $(REGISTRY)/$(REPOSITORY):$(DEFAULT_TAG) bayesian-api
+	docker tag $(REGISTRY)/$(REPOSITORY):$(DEFAULT_TAG) $(IMAGE_NAME)
 
 fast-docker-build: hack/coreapi-release
 	docker build -t $(REGISTRY)/$(REPOSITORY):$(DEFAULT_TAG) -f $(DOCKERFILE) .
-	docker tag $(REGISTRY)/$(REPOSITORY):$(DEFAULT_TAG) bayesian-api
+	docker tag $(REGISTRY)/$(REPOSITORY):$(DEFAULT_TAG) $(IMAGE_NAME)
 
 test: fast-docker-build
 	./runtest.sh

--- a/cico_setup.sh
+++ b/cico_setup.sh
@@ -39,7 +39,7 @@ docker_login() {
 
 build_image() {
     # build image and tests
-    make docker-build-tests
+    make docker-build
 }
 
 tag_push() {

--- a/qa/runtest.sh
+++ b/qa/runtest.sh
@@ -40,7 +40,7 @@ trap gc EXIT SIGINT
 if [ "$REBUILD" == "1" ] || \
      !(docker inspect $IMAGE_NAME > /dev/null 2>&1); then
   echo "Building $IMAGE_NAME for testing"
-  docker build --tag="$IMAGE_NAME" .
+  make docker-build
 fi
 
 echo "Creating network ${DOCKER_NETWORK}"

--- a/qa/runtest.sh
+++ b/qa/runtest.sh
@@ -40,7 +40,7 @@ trap gc EXIT SIGINT
 if [ "$REBUILD" == "1" ] || \
      !(docker inspect $IMAGE_NAME > /dev/null 2>&1); then
   echo "Building $IMAGE_NAME for testing"
-  make docker-build
+  make docker-build IMAGE_NAME=$IMAGE_NAME
 fi
 
 echo "Creating network ${DOCKER_NETWORK}"


### PR DESCRIPTION
`fast-docker-build-tests` is stale because Dockerfile.tests are no longer exist. Fix the broken makefile and use make targets from qa/runtest.sh to evaluate makefile changes as part of PR check.