### PR TITLE
fix: enable gunicorn access logs

### DIFF
--- a/bayesian/conf/gunicorn.py
+++ b/bayesian/conf/gunicorn.py
@@ -13,6 +13,7 @@ timeout = GUNICORN_SETTINGS.timeout
 preload_app = GUNICORN_SETTINGS.preload
 worker_connections = GUNICORN_SETTINGS.worker_connections
 reload = preload_app is not True
+accesslog = "-"
 
 
 def when_ready(server):  # noqa


### PR DESCRIPTION
This is to match the debugging behaviour w.r.t to the previous apache based deployment.

Also this will help us to inspect the user agent.

Sample logs:

```
172.17.0.1 - - [11/Feb/2021:06:47:53 +0000] "GET / HTTP/1.1" 302 221 "-" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/88.0.4324.152 Safari/537.36"
172.17.0.1 - - [11/Feb/2021:06:47:53 +0000] "GET /api/v2 HTTP/1.1" 200 185 "-" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/88.0.4324.152 Safari/537.36"
```