### PR TITLE
fix: add snyk attribution and utm to CA response

### DIFF
--- a/bayesian/api/api_v2.py
+++ b/bayesian/api/api_v2.py
@@ -51,6 +51,8 @@ from bayesian.utility.v2.backbone_server import BackboneServerException
 from bayesian.utility.db_gateway import (RdbAnalyses, RDBSaveException,
                                          RDBInvalidRequestException,
                                          RDBServerException)
+from bayesian.settings import SNYK_SETTINGS
+from bayesian.utility.snyk import Enricher
 from werkzeug.exceptions import BadRequest
 from f8a_utils.ingestion_utils import unknown_package_flow
 from f8a_utils import ingestion_utils
@@ -215,6 +217,10 @@ class ComponentAnalysesApi(Resource):
             msg = "Internal Server Exception. Please contact us if problem persists."
             logger.error(e)
             raise HTTPError(400, msg) from e
+
+        if request.user_agent.string == "claircore/crda/RemoteMatcher":
+            snyk = Enricher(ecosystem, SNYK_SETTINGS.attribution, SNYK_SETTINGS.utm)
+            snyk.add_attribution_with_utm(stack_recommendation)
 
         create_component_bookkeeping(ecosystem, packages_list, request.args, request.headers)
 

--- a/bayesian/settings.py
+++ b/bayesian/settings.py
@@ -26,11 +26,26 @@ class ComponentAnalysesSettings(BaseSettings):
     concurrency_limit: int = Field(default=2, env="COMPONENT_ANALYSES_CONCURRENCY_LIMIT")
 
 
+class SynkAttributionSettings(BaseSettings):
+    """Snyk attribution related params."""
+
+    attribution: str = Field(
+        default="",
+        env="SNYK_ATTRIBUTION",
+    )
+    utm: str = Field(
+        default="",
+        env="SNYK_UTM",
+    )
+
+
 GUNICORN_SETTINGS = GunicornSettings()
 COMPONENT_ANALYSES_SETTINGS = ComponentAnalysesSettings()
+SNYK_SETTINGS = SynkAttributionSettings()
 
 
 def log_all_settings():
     """Use for debugging."""
     logger.info("gunicorn: %s", str(GUNICORN_SETTINGS.dict()))
     logger.info("component analysis: %s", str(COMPONENT_ANALYSES_SETTINGS.dict()))
+    logger.info("snyk attribution: %s", str(SNYK_SETTINGS.dict()))

--- a/bayesian/utility/snyk.py
+++ b/bayesian/utility/snyk.py
@@ -1,0 +1,46 @@
+"""Snyk related response data enricher."""
+
+from urllib.parse import quote
+from typing import Dict, List
+
+
+class Enricher:
+    """Response data Enricher."""
+
+    __ECOSYSTEM_SYNONYM = {
+        "pypi": "pip",
+    }
+
+    def __init__(self, ecosystem: str, attribution: str, utm: str):
+        """Create Enricher based on given attribution, utm and ecosystem."""
+        assert attribution is not None
+        assert utm is not None
+        assert ecosystem is not None
+
+        self.__attribution = attribution
+        self.__utm = utm
+        # use the given ecosystem if no synonym found.
+        self.__ecosystem = self.__ECOSYSTEM_SYNONYM.get(ecosystem, ecosystem)
+
+    def __append_utm_in_url(self, package: str, vuln: Dict) -> Dict:
+        url = vuln.get("url")
+        if url is not None:
+            package = quote(package, safe="")
+            utm = self.__utm.format(ecosystem=self.__ecosystem, package=package)
+            vuln["url"] = f"{url}?{utm}"
+        return vuln
+
+    def __append_attribution_in_title(self, vuln: Dict) -> Dict:
+        title = vuln.get("title")
+        if title is not None:
+            vuln["title"] = f"{title} {self.__attribution}"
+        return vuln
+
+    def add_attribution_with_utm(self, payload: List[Dict]) -> List[Dict]:
+        """Update title and url based on attribution and utm params."""
+        for item in payload:
+            package = item.get("package")
+            for vuln in item.get("vulnerability", []):
+                self.__append_attribution_in_title(vuln)
+                self.__append_utm_in_url(package, vuln)
+        return payload

--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -56,6 +56,10 @@ objects:
             value: "True"
           - name: WORKER_CONNECTIONS
             value: ${WORKER_CONNECTIONS}
+          - name: SNYK_ATTRIBUTION
+            value: ${SNYK_ATTRIBUTION}
+          - name: SNYK_UTM
+            value: ${SNYK_UTM}
           - name: OSIO_AUTH_URL
             valueFrom:
               configMapKeyRef:
@@ -297,3 +301,15 @@ parameters:
   required: true
   name: WORKER_COUNT
   value: "2"
+
+- description: Snyk attribution text
+  displayName: Snyk attribution text
+  required: true
+  name: SNYK_ATTRIBUTION
+  value: "(data source: https://snyk.io/vuln) Sign up at https://snyk.co/crda"
+
+- description: Snyk UTM
+  displayName: Snyk UTM
+  required: true
+  name: SNYK_UTM
+  value: "utm_medium=Partner&utm_source=RedHat&utm_campaign=Code-Ready-Analytics-2020&utm_content=vuln/{ecosystem}:{package}"

--- a/tests/api/test_api_v2.py
+++ b/tests/api/test_api_v2.py
@@ -139,8 +139,8 @@ class TestCAPostApi(unittest.TestCase):
     @classmethod
     def setUpClass(cls) -> None:
         """Init Test class."""
-        gremlin_batch_data = os.path.join('/bayesian/tests/data/gremlin/gremlin_batch_data.json')
-        recommendation_data = os.path.join('/bayesian/tests/data/response/ca_batch_response.json')
+        gremlin_batch_data = os.path.join('tests/data/gremlin/gremlin_batch_data.json')
+        recommendation_data = os.path.join('tests/data/response/ca_batch_response.json')
 
         with open(gremlin_batch_data) as f:
             cls.gremlin_batch_data = json.load(f)

--- a/tests/utility/test_snyk.py
+++ b/tests/utility/test_snyk.py
@@ -1,0 +1,85 @@
+"""Tests for snyk enricher which adds attribution and utm params."""
+from bayesian.utility.snyk import Enricher
+
+
+def test_enricher_construction():
+    """Test obj constrution."""
+    assert Enricher(ecosystem="pypi", attribution="", utm="") is not None
+
+
+def test_enricher_with_empty_input_array():
+    """Test obj constrution with empty payload."""
+    enricher = Enricher(ecosystem="pypi", attribution="(hello world)", utm="utm")
+    result = enricher.add_attribution_with_utm([])
+    assert [] == result
+
+
+def test_enricher_with_empty_input_array_dict():
+    """Test obj constrution with empty payload."""
+    enricher = Enricher(ecosystem="pypi", attribution="(hello world)", utm="utm")
+    result = enricher.add_attribution_with_utm([{}])
+    assert [{}] == result
+
+
+def test_enricher_with_valid_title():
+    """Test obj constrution with valid title."""
+    enricher = Enricher(ecosystem="pypi", attribution="(hello world)", utm="utm")
+    result = enricher.add_attribution_with_utm([{"vulnerability": [{"title": "foo"}]}])
+    assert [{"vulnerability": [{"title": "foo (hello world)"}]}] == result
+
+
+def test_enricher_with_valid_titles():
+    """Test obj constrution with valid titles."""
+    enricher = Enricher(ecosystem="pypi", attribution="(hello world)", utm="utm")
+    result = enricher.add_attribution_with_utm(
+        [{"vulnerability": [{"title": "foo"}, {"title": "bar"}]}]
+    )
+    assert [
+        {
+            "vulnerability": [
+                {"title": "foo (hello world)"},
+                {"title": "bar (hello world)"},
+            ]
+        }
+    ] == result
+
+
+def test_enricher_with_valid_url():
+    """Test obj constrution with valid title and url."""
+    enricher = Enricher(
+        ecosystem="pypi",
+        attribution="(hello world)",
+        utm="u_m=P&u_s=RH&u_c=2021&utm_content=vuln/{ecosystem}:{package}",
+    )
+    result = enricher.add_attribution_with_utm(
+        [
+            {
+                "package": "foo:pkg",
+                "vulnerability": [{"title": "foo", "url": "http://foo"}],
+            },
+            {
+                "package": "bar:pkg",
+                "vulnerability": [{"title": "bar", "url": "http://bar"}],
+            },
+        ]
+    )
+    assert [
+        {
+            "package": "foo:pkg",
+            "vulnerability": [
+                {
+                    "title": "foo (hello world)",
+                    "url": "http://foo?u_m=P&u_s=RH&u_c=2021&utm_content=vuln/pip:foo%3Apkg",
+                },
+            ],
+        },
+        {
+            "package": "bar:pkg",
+            "vulnerability": [
+                {
+                    "title": "bar (hello world)",
+                    "url": "http://bar?u_m=P&u_s=RH&u_c=2021&utm_content=vuln/pip:bar%3Apkg",
+                },
+            ],
+        },
+    ] == result


### PR DESCRIPTION
This PR adds snyk attribution and utm param for requests coming from Clair component. This is just a stop gap solution to unblock Quay 3.5.2 release.

### Sample response
```
[
    {
        "package_unknown": false,
        "package": "github.com/slackhq/nebula@github.com/slackhq/nebula/cert",
        "version": "v1.1.0",
        "recommended_versions": "v1.3.0",
        "registration_link": "https://app.snyk.io/login",
        "vulnerability": [
            {
                "id": "SNYK-GOLANG-GITHUBCOMSLACKHQNEBULA-564380",
                "cvss": "7.5",
                "is_private": false,
                "cwes": [
                    "CWE-23"
                ],
                "cvss_v3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N/E:U/RL:O/RC:R",
                "severity": "high",
                "title": "Path Traversal (data source: https://snyk.io/vuln) Sign up at https://snyk.co/crda",
                "url": "https://snyk.io/vuln/SNYK-GOLANG-GITHUBCOMSLACKHQNEBULA-564380?utm_medium=Partner&utm_source=RedHat&utm_campaign=Code-Ready-Analytics-2020&utm_content=vuln/golang:github.com%2Fslackhq%2Fnebula%40github.com%2Fslackhq%2Fnebula%2Fcert",
                "cve_ids": [
                    "CVE-2020-11498"
                ],
                "fixed_in": [
                    "1.2.0"
                ]
            }
        ],
        "message": "github.com/slackhq/nebula@github.com/slackhq/nebula/cert - v1.1.0 has 1 known security vulnerability having high severity. Recommendation: use version v1.3.0.",
        "highest_severity": "high",
        "known_security_vulnerability_count": 1,
        "security_advisory_count": 0
    }
]
```

Signed-off-by: Arunprasad Rajkumar <arajkuma@redhat.com>