### PR TITLE
fix: add trailing slash in CA post route definition

### DIFF
--- a/bayesian/api/api_v2.py
+++ b/bayesian/api/api_v2.py
@@ -99,6 +99,7 @@ def component_analyses_get(ecosystem, package, version):
     return jsonify(msg), 404
 
 
+@api_v2.route('/component-analyses/', methods=['POST'])
 @api_v2.route('/component-analyses', methods=['POST'])
 @validate_user
 @login_required


### PR DESCRIPTION
https://github.com/fabric8-analytics/fabric8-analytics-server/pull/755 removed a slashless and slashful workaround. The simplest solution now is define additional route with extra trailing slash.

signed off by msawood@redhat.com